### PR TITLE
Features/issue 29 implement logic to send user confirmation email

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -42,7 +42,7 @@ config :api, I18NAPI.Repo,
   username: "postgres",
   password: "postgres",
   database: "i18n_api_dev",
-  hostname: "db",
+  hostname: "localhost",
   pool_size: 10
 
 config :api, I18NAPI.Guardian,
@@ -53,3 +53,6 @@ config :api, I18NAPI.Guardian,
   verify_issuer: true,
   secret_key: "dev",
   serializer: I18NAPI.Guardian
+
+config :api, I18NAPI.Mailer,
+       adapter: Swoosh.Adapters.Local

--- a/config/test.exs
+++ b/config/test.exs
@@ -12,11 +12,12 @@ config :logger, level: :warn
 # Configure your database
 config :api, I18NAPI.Repo,
   adapter: Ecto.Adapters.Postgres,
-  username: "Judis",
-  password: "",
+  username: "postgres",
+  password: "postgres",
   database: "i18n_api_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
 
 config :api, I18NAPI.Guardian,
   allowed_algos: ["HS512"],
@@ -28,3 +29,6 @@ config :api, I18NAPI.Guardian,
   serializer: I18NAPI.Guardian
 
 config :bcrypt_elixir, :log_rounds, 4
+
+config :api, I18NAPI.Mailer,
+       adapter: Swoosh.Adapters.Test

--- a/lib/api/accounts/accounts.ex
+++ b/lib/api/accounts/accounts.ex
@@ -4,11 +4,11 @@ defmodule I18NAPI.Accounts do
   """
 
   import Ecto.Query, warn: false
+  import I18NAPI.Accounts.Confirmation
+
+  alias I18NAPI.Accounts.User
   alias I18NAPI.Repo
   alias I18NAPI.Utilites
-  alias I18NAPI.UserEmail
-  alias I18NAPI.Accounts.User
-  alias I18NAPI.Accounts.Confirmation
 
   @doc """
   Returns the list of users.
@@ -53,9 +53,20 @@ defmodule I18NAPI.Accounts do
   """
   def create_user(attrs \\ %{}) do
     %User{}
-    |> User.changeset(attrs)
+    |> User.changeset(
+      attrs
+      |> Map.put(:confirmation_token, Utilites.random_string(32))
+      |> Utilites.key_to_atom()
+    )
     |> Repo.insert()
-    |> Confirmation.send_confirmation_email_async
+    |> send_email_if_user_created()
+  end
+
+  defp send_email_if_user_created({:error, _} = result), do: result
+
+  defp send_email_if_user_created({:ok, user}) do
+    send_confirmation_email_async(user)
+    {:ok, user}
   end
 
   @doc """
@@ -145,16 +156,16 @@ defmodule I18NAPI.Accounts do
   """
   def find_user_by_confirmation_token(confirmation_token) do
     case Repo.get_by(User, confirmation_token: confirmation_token) do
-      nil  -> {:error, :unauthorized}
+      nil -> {:error, :unauthorized}
       user -> {:ok, user}
     end
   end
 
-  def add_confirmation_token_to_user(%User{} = user, confirmation_token) do
+  def update_field_confirmation_sent_at(%User{} = user) do
     attrs = %{
-      confirmation_token: confirmation_token,
-      confirmation_sent_at: NaiveDateTime.utc_now
+      confirmation_sent_at: NaiveDateTime.utc_now()
     }
+
     user
     |> User.confirmation_changeset(attrs)
     |> Repo.update()
@@ -164,9 +175,10 @@ defmodule I18NAPI.Accounts do
     attrs = %{
       confirmation_token: nil,
       confirmation_sent_at: nil,
-      confirmed_at: NaiveDateTime.utc_now,
+      confirmed_at: NaiveDateTime.utc_now(),
       is_confirmed: true
     }
+
     user
     |> User.confirmation_changeset(attrs)
     |> Repo.update()

--- a/lib/api/accounts/confirmation.ex
+++ b/lib/api/accounts/confirmation.ex
@@ -1,0 +1,39 @@
+defmodule I18NAPI.Accounts.Confirmation do
+  @moduledoc """
+  The Accounts context.
+  """
+
+  import Ecto.Query, warn: false
+  alias I18NAPI.Repo
+  alias I18NAPI.Mailer
+  alias I18NAPI.Utilites
+  alias I18NAPI.UserEmail
+  alias I18NAPI.Accounts
+  alias I18NAPI.Accounts.User
+
+
+  def send_confirmation_email_async({:error, _} = result) do
+    result
+  end
+
+  def send_confirmation_email_async({:ok, %User{} = user} = result) do
+    spawn(I18NAPI.Accounts.Confirmation, :send_confirmation_email, [result])
+    result
+  end
+
+  def send_confirmation_email({:ok, %User{} = user}) do
+    confirmation_token = Utilites.random_string(32)
+
+    email = UserEmail.deliver_confirmation_email(user |> Map.put(:confirmation_token, confirmation_token))
+
+    user |> Accounts.update_user(%{
+      confirmation_token: confirmation_token,
+      confirmation_send_at: NaiveDateTime.utc_now
+    })
+  end
+
+  def confirm_user_by_token(confirmation_token) do
+    with {:ok, user} <- Accounts.find_user_by_confirmation_token(confirmation_token),
+         {:ok, user} <- Accounts.confirm_user(user), do: {:ok}
+  end
+end

--- a/lib/api/accounts/confirmation.ex
+++ b/lib/api/accounts/confirmation.ex
@@ -23,17 +23,17 @@ defmodule I18NAPI.Accounts.Confirmation do
 
   def send_confirmation_email({:ok, %User{} = user}) do
     confirmation_token = Utilites.random_string(32)
-
-    email = UserEmail.deliver_confirmation_email(user |> Map.put(:confirmation_token, confirmation_token))
-
-    user |> Accounts.update_user(%{
-      confirmation_token: confirmation_token,
-      confirmation_send_at: NaiveDateTime.utc_now
-    })
+    UserEmail.create_confirmation_email(user |> Map.put(:confirmation_token, confirmation_token))
+    Accounts.add_confirmation_token_to_user(user, confirmation_token)
   end
 
+  def confirm_user_by_token(nil), do: {:error, :not_found}
   def confirm_user_by_token(confirmation_token) do
     with {:ok, user} <- Accounts.find_user_by_confirmation_token(confirmation_token),
          {:ok, user} <- Accounts.confirm_user(user), do: {:ok}
+  end
+
+  def create_confirmation_link(confirmation_token) do
+    I18NAPIWeb.Router.Helpers.confirmation_url(I18NAPIWeb.Endpoint, :confirm, token: confirmation_token)
   end
 end

--- a/lib/api/accounts/confirmation.ex
+++ b/lib/api/accounts/confirmation.ex
@@ -1,39 +1,35 @@
 defmodule I18NAPI.Accounts.Confirmation do
   @moduledoc """
-  The Accounts context.
+  The user confirmation context.
   """
 
   import Ecto.Query, warn: false
-  alias I18NAPI.Repo
-  alias I18NAPI.Mailer
-  alias I18NAPI.Utilites
-  alias I18NAPI.UserEmail
   alias I18NAPI.Accounts
   alias I18NAPI.Accounts.User
+  alias I18NAPI.Mailer
+  alias I18NAPI.UserEmail
 
-
-  def send_confirmation_email_async({:error, _} = result) do
-    result
+  def send_confirmation_email_async(user) do
+    spawn(I18NAPI.Accounts.Confirmation, :send_confirmation_email, [user])
   end
 
-  def send_confirmation_email_async({:ok, %User{} = user} = result) do
-    spawn(I18NAPI.Accounts.Confirmation, :send_confirmation_email, [result])
-    result
-  end
-
-  def send_confirmation_email({:ok, %User{} = user}) do
-    confirmation_token = Utilites.random_string(32)
-    UserEmail.create_confirmation_email(user |> Map.put(:confirmation_token, confirmation_token))
-    Accounts.add_confirmation_token_to_user(user, confirmation_token)
+  def send_confirmation_email(%User{} = user) do
+    with {:ok, _} <- Mailer.deliver(UserEmail.create_confirmation_email(user)) do
+      Accounts.update_field_confirmation_sent_at(user)
+    end
   end
 
   def confirm_user_by_token(nil), do: {:error, :not_found}
+
   def confirm_user_by_token(confirmation_token) do
     with {:ok, user} <- Accounts.find_user_by_confirmation_token(confirmation_token),
-         {:ok, user} <- Accounts.confirm_user(user), do: {:ok}
+         {:ok, _} <- Accounts.confirm_user(user),
+         do: {:ok}
   end
 
   def create_confirmation_link(confirmation_token) do
-    I18NAPIWeb.Router.Helpers.confirmation_url(I18NAPIWeb.Endpoint, :confirm, token: confirmation_token)
+    I18NAPIWeb.Router.Helpers.confirmation_url(I18NAPIWeb.Endpoint, :confirm,
+      token: confirmation_token
+    )
   end
 end

--- a/lib/api/accounts/user.ex
+++ b/lib/api/accounts/user.ex
@@ -55,6 +55,17 @@ defmodule I18NAPI.Accounts.User do
   end
 
   @doc false
+  def confirmation_changeset(user, attrs) do
+    user
+    |> cast(attrs, [
+      :confirmation_token,
+      :confirmation_sent_at,
+      :confirmed_at,
+      :is_confirmed,
+    ])
+  end
+
+  @doc false
   defp generate_password_hash(changeset) do
     case changeset do
       %Ecto.Changeset{valid?: true, changes: %{password: password}} ->

--- a/lib/api/projects/project.ex
+++ b/lib/api/projects/project.ex
@@ -10,6 +10,8 @@ defmodule I18NAPI.Projects.Project do
     field(:removed_at, :naive_datetime)
     field(:default_locale, :string, virtual: true)
 
+    field(:total_count_of_translation_keys, :integer, default: 0)
+
     has_many(:user_roles, UserRoles, on_delete: :delete_all)
     has_many(:locales, Locale, on_delete: :delete_all)
     has_many(:translation_keys, TranslationKey, on_delete: :delete_all)

--- a/lib/api/projects/project.ex
+++ b/lib/api/projects/project.ex
@@ -10,9 +10,9 @@ defmodule I18NAPI.Projects.Project do
     field(:removed_at, :naive_datetime)
     field(:default_locale, :string, virtual: true)
 
-    has_many(:user_roles, UserRoles)
-    has_many(:locales, Locale)
-    has_many(:translation_keys, TranslationKey)
+    has_many(:user_roles, UserRoles, on_delete: :delete_all)
+    has_many(:locales, Locale, on_delete: :delete_all)
+    has_many(:translation_keys, TranslationKey, on_delete: :delete_all)
 
     timestamps()
   end

--- a/lib/api/projects/project.ex
+++ b/lib/api/projects/project.ex
@@ -11,6 +11,11 @@ defmodule I18NAPI.Projects.Project do
     field(:default_locale, :string, virtual: true)
 
     field(:total_count_of_translation_keys, :integer, default: 0)
+    field(:count_of_not_verified_keys, :integer, default: 0)
+    field(:count_of_verified_keys, :integer, default: 0)
+    field(:count_of_translated_keys, :integer, default: 0)
+    field(:count_of_untranslated_keys, :integer, default: 0)
+    field(:count_of_keys_need_check, :integer, default: 0)
 
     has_many(:user_roles, UserRoles, on_delete: :delete_all)
     has_many(:locales, Locale, on_delete: :delete_all)

--- a/lib/api/projects/projects.ex
+++ b/lib/api/projects/projects.ex
@@ -7,7 +7,13 @@ defmodule I18NAPI.Projects do
   alias I18NAPI.Repo
 
   alias I18NAPI.Projects.Project
+  alias I18NAPI.Translations
+  alias I18NAPI.Translations.Locale
 
+  def default_locale_to_project(%Project{} = project) do
+    locale = Translations.get_default_locale!(project.id)
+    %{project | default_locale: locale.locale}
+  end
   @doc """
   Returns the list of projects.
 
@@ -19,6 +25,7 @@ defmodule I18NAPI.Projects do
   """
   def list_projects do
     Repo.all(Project)
+    |> Enum.map(fn p -> default_locale_to_project(p) end)
   end
 
   @doc """
@@ -41,6 +48,7 @@ defmodule I18NAPI.Projects do
       )
 
     Repo.all(query)
+    |> Enum.map(fn p -> default_locale_to_project(p) end)
   end
 
   @doc """
@@ -57,7 +65,7 @@ defmodule I18NAPI.Projects do
       ** (Ecto.NoResultsError)
 
   """
-  def get_project!(id), do: Repo.get!(Project, id)
+  def get_project!(id), do: Repo.get!(Project, id) |> default_locale_to_project()
 
   @doc """
   Creates a project.

--- a/lib/api/projects/projects.ex
+++ b/lib/api/projects/projects.ex
@@ -68,12 +68,15 @@ defmodule I18NAPI.Projects do
   def get_project!(id), do: Repo.get!(Project, id) |> default_locale_to_project()
 
   def get_total_count_of_translation_keys(project_id) do
-    from(
-      p in Project,
-      where: [id: ^project_id],
-      select: [p.total_count_of_translation_keys]
-    )
-    |> Repo.one!()
+    [head|_] =
+      from(
+        p in Project,
+        where: [id: ^project_id],
+        select: [p.total_count_of_translation_keys]
+      )
+      |> Repo.one!()
+
+    head
   end
   @doc """
   Creates a project.
@@ -159,27 +162,6 @@ defmodule I18NAPI.Projects do
     project
     |> Project.changeset(attrs)
     |> Repo.update()
-  end
-
-  @doc """
-  Inc/decrement a project field :total_count_of_translation_keys.
-
-  ## Examples
-
-      iex> update_total_count_of_translation_keys(project_id)
-      {:ok, %Project{}}
-
-      iex> update_total_count_of_translation_keys(project_id, :dec)
-      {:ok, %Project{}}
-
-  """
-  def update_total_count_of_translation_keys(project_id, operation \\ :inc)
-  def update_total_count_of_translation_keys(project_id, operation) when ((:inc == operation) or (:dec == operation)) do
-    query = from(p in Project, where: [id: ^project_id])
-    case operation do
-      :inc -> Repo.update(query, inc: [total_count_of_translation_keys: 1])
-      :dec -> Repo.update(query, dec: [total_count_of_translation_keys: 1])
-    end
   end
 
   @doc """

--- a/lib/api/projects/projects.ex
+++ b/lib/api/projects/projects.ex
@@ -67,6 +67,14 @@ defmodule I18NAPI.Projects do
   """
   def get_project!(id), do: Repo.get!(Project, id) |> default_locale_to_project()
 
+  def get_total_count_of_translation_keys(project_id) do
+    from(
+      p in Project,
+      where: [id: ^project_id],
+      select: [p.total_count_of_translation_keys]
+    )
+    |> Repo.one!()
+  end
   @doc """
   Creates a project.
 
@@ -151,6 +159,27 @@ defmodule I18NAPI.Projects do
     project
     |> Project.changeset(attrs)
     |> Repo.update()
+  end
+
+  @doc """
+  Inc/decrement a project field :total_count_of_translation_keys.
+
+  ## Examples
+
+      iex> update_total_count_of_translation_keys(project_id)
+      {:ok, %Project{}}
+
+      iex> update_total_count_of_translation_keys(project_id, :dec)
+      {:ok, %Project{}}
+
+  """
+  def update_total_count_of_translation_keys(project_id, operation \\ :inc)
+  def update_total_count_of_translation_keys(project_id, operation) when ((:inc == operation) or (:dec == operation)) do
+    query = from(p in Project, where: [id: ^project_id])
+    case operation do
+      :inc -> Repo.update(query, inc: [total_count_of_translation_keys: 1])
+      :dec -> Repo.update(query, dec: [total_count_of_translation_keys: 1])
+    end
   end
 
   @doc """

--- a/lib/api/projects/projects.ex
+++ b/lib/api/projects/projects.ex
@@ -239,6 +239,30 @@ defmodule I18NAPI.Projects do
   def get_user_roles!(id), do: Repo.get!(UserRoles, id)
 
   @doc """
+  Gets a single user_roles.
+
+  Raises `Ecto.NoResultsError` if the User roles does not exist.
+
+  ## Examples
+
+      iex> get_user_roles!(123, 321)
+      %UserRoles{}
+
+      iex> get_user_roles!(456, 654)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_user_roles!(project_id, user_id) do
+    query =
+      from(
+        ur in UserRoles,
+        where: ur.project_id == ^project_id and ur.user_id == ^user_id
+      )
+
+    Repo.one(query)
+  end
+
+  @doc """
   Creates a user_roles.
 
   ## Examples

--- a/lib/api/projects/user_locales.ex
+++ b/lib/api/projects/user_locales.ex
@@ -11,7 +11,14 @@ defmodule I18NAPI.Projects.UserLocales do
   end
 
   @doc false
-  def changeset(user_locales, attrs) do
+  def create_changeset(user_locales, attrs) do
+    user_locales
+    |> cast(attrs, [:user_id, :locale_id, :role])
+    |> validate_required([:role])
+  end
+
+  @doc false
+  def update_changeset(user_locales, attrs) do
     user_locales
     |> cast(attrs, [:role])
     |> validate_required([:role])

--- a/lib/api/translations/locale.ex
+++ b/lib/api/translations/locale.ex
@@ -1,6 +1,7 @@
 defmodule I18NAPI.Translations.Locale do
   use Ecto.Schema
   import Ecto.Changeset
+  alias I18NAPI.Projects.{UserLocales}
 
   schema "locales" do
     field(:is_default, :boolean, default: false)
@@ -16,6 +17,7 @@ defmodule I18NAPI.Translations.Locale do
     field(:count_of_keys_need_check, :integer, default: 0)
 
     belongs_to(:project, I18NAPI.Projects.Project)
+    has_many(:user_locales, UserLocales, on_delete: :delete_all)
     has_many(:translations, I18NAPI.Translations.Translation)
 
     timestamps()

--- a/lib/api/translations/locale.ex
+++ b/lib/api/translations/locale.ex
@@ -3,13 +3,16 @@ defmodule I18NAPI.Translations.Locale do
   import Ecto.Changeset
 
   schema "locales" do
-    field(:count_of_keys, :integer)
-    field(:count_of_translated_keys, :integer)
-    field(:count_of_words, :integer)
     field(:is_default, :boolean, default: false)
     field(:is_removed, :boolean, default: false)
     field(:locale, :string)
     field(:removed_at, :naive_datetime)
+
+    field(:count_of_not_verified_keys, :integer, default: 0)
+    field(:count_of_verified_keys, :integer, default: 0)
+    field(:count_of_translated_keys, :integer, default: 0)
+    field(:count_of_untranslated_keys, :integer, default: 0)
+    field(:count_of_keys_need_check, :integer, default: 0)
 
     belongs_to(:project, I18NAPI.Projects.Project)
     has_many(:translations, I18NAPI.Translations.Translation)

--- a/lib/api/translations/locale.ex
+++ b/lib/api/translations/locale.ex
@@ -8,6 +8,7 @@ defmodule I18NAPI.Translations.Locale do
     field(:locale, :string)
     field(:removed_at, :naive_datetime)
 
+    field(:total_count_of_translation_keys, :integer, default: 0)
     field(:count_of_not_verified_keys, :integer, default: 0)
     field(:count_of_verified_keys, :integer, default: 0)
     field(:count_of_translated_keys, :integer, default: 0)

--- a/lib/api/translations/statistics.ex
+++ b/lib/api/translations/statistics.ex
@@ -7,8 +7,8 @@ defmodule I18NAPI.Translations.Statistics do
   alias I18NAPI.Utilites
   alias I18NAPI.Projects
   alias I18NAPI.Projects.Project
-  alias I18NAPI.Translations.Locale
-  alias I18NAPI.Translations.Translation
+  alias I18NAPI.Translations
+  alias I18NAPI.Translations.{Locale, Translation, TranslationKey}
 
   @doc """
   Inc/decrement a project field :total_count_of_translation_keys.
@@ -27,14 +27,27 @@ defmodule I18NAPI.Translations.Statistics do
       when ((:inc == operation) or (:dec == operation)) and is_integer(value) do
     if (:dec == operation), do: value = -value
 
-    Task.async(fn ->
       query = from(p in Project, where: [id: ^project_id])
       Repo.update_all(query, inc: [total_count_of_translation_keys: value])
-    end)
+  end
+
+  def update_total_count_of_translation_keys_async(project_id, operation, value \\ 1)
+  def update_total_count_of_translation_keys_async(project_id, operation, value) do
+    spawn(I18NAPI.Translations.Statistics, :update_total_count_of_translation_keys, [project_id, operation, value])
+  end
+
+  def update_basic_statistics(project_id, operation, value \\ 1)
+  def update_basic_statistics(project_id, operation, value) do
+    update_total_count_of_translation_keys(project_id, operation, value)
+    recalculate_count_of_untranslated_keys_at_locales(project_id)
+  end
+
+  def update_basic_statistics_async(project_id, operation, value \\ 1)
+  def update_basic_statistics_async(project_id, operation, value) do
+    spawn(I18NAPI.Translations.Statistics, :update_basic_statistics, [project_id, operation, value])
   end
 
   def recalculate_count_of_untranslated_keys_at_locales(project_id) do
-    Task.async(fn ->
       Repo.transaction(fn ->
         total = Projects.get_total_count_of_translation_keys(project_id)
 
@@ -43,17 +56,20 @@ defmodule I18NAPI.Translations.Statistics do
         |> Repo.update_all([])
 
       end)
-    end)
+  end
+
+  def recalculate_count_of_untranslated_keys_at_locales_async(project_id) do
+    spawn(I18NAPI.Translations.Statistics, :recalculate_count_of_untranslated_keys_at_locales, [project_id])
   end
 
   def update_count_of_keys_at_locales(locale_id, operation, key, value \\ 1)
   def update_count_of_keys_at_locales(locale_id, operation, key, value)
       when ((:inc == operation) or (:dec == operation))
            and is_integer(value) do
+
     if (:dec == operation), do: value = -value
     query = from(l in Locale, where: [id: ^locale_id])
 
-    Task.async(fn ->
       case key do
         :translated   -> Repo.update_all(query, inc: [count_of_translated_keys: value])
         :untranslated -> Repo.update_all(query, inc: [count_of_untranslated_keys: value])
@@ -61,7 +77,11 @@ defmodule I18NAPI.Translations.Statistics do
         :not_verified -> Repo.update_all(query, inc: [count_of_not_verified_keys: value])
         :need_check   -> Repo.update_all(query, inc: [count_of_keys_need_check: value])
       end
-    end)
+  end
+
+  def update_count_of_keys_at_locales_async(locale_id, operation, key, value \\ 1)
+  def update_count_of_keys_at_locales_async(locale_id, operation, key, value) do
+    spawn(I18NAPI.Translations.Statistics, :update_count_of_keys_at_locales, [locale_id, operation, value])
   end
 
   def update_count_choice(locale_id, prev_status, new_status) do
@@ -80,7 +100,7 @@ defmodule I18NAPI.Translations.Statistics do
         update_count_of_keys_at_locales(locale_id, :inc, :untranslated)
         update_count_of_keys_at_locales(locale_id, :inc, :need_check)
 
-      {:unverified, :empty} -> fn ->
+      {:unverified, :empty} ->
         update_count_of_keys_at_locales(locale_id, :dec, :translated)
         update_count_of_keys_at_locales(locale_id, :inc, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :not_verified)
@@ -95,7 +115,7 @@ defmodule I18NAPI.Translations.Statistics do
         update_count_of_keys_at_locales(locale_id, :dec, :not_verified)
         update_count_of_keys_at_locales(locale_id, :inc, :need_check)
 
-      {:verified, :empty} -> fn ->
+      {:verified, :empty} ->
         update_count_of_keys_at_locales(locale_id, :dec, :translated)
         update_count_of_keys_at_locales(locale_id, :inc, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :verified)
@@ -110,7 +130,7 @@ defmodule I18NAPI.Translations.Statistics do
         update_count_of_keys_at_locales(locale_id, :dec, :verified)
         update_count_of_keys_at_locales(locale_id, :inc, :need_check)
 
-      {:need_check, :empty} -> fn ->
+      {:need_check, :empty} ->
         update_count_of_keys_at_locales(locale_id, :dec, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :need_check)
 
@@ -126,7 +146,121 @@ defmodule I18NAPI.Translations.Statistics do
         update_count_of_keys_at_locales(locale_id, :dec, :need_check)
         update_count_of_keys_at_locales(locale_id, :inc, :not_verified)
 
+        _ ->
     end
   end
+
+  def update_count_choice_async(locale_id, prev_status, new_status) do
+    spawn(I18NAPI.Translations.Statistics, :update_count_choice, [locale_id, prev_status, new_status])
+  end
+
+  def calculate_count_of_keys_at_locale_by_status(locale_id, status, is_removed \\ false) do
+    from(
+      t in Translation,
+      where: [locale_id: ^locale_id],
+      where: [status: ^status],
+      where: [is_removed: ^is_removed],
+      select: count(t.id)
+    )
+    |> Repo.one!()
+  end
+
+  def calculate_total_count_of_translation_keys_at_project(project_id, is_removed \\ false) do
+    from(
+      tk in TranslationKey,
+      where: [project_id: ^project_id],
+      where: [is_removed: ^is_removed],
+      select: count(tk.id)
+    )
+    |> Repo.one!()
+  end
+
+  @doc """
+  Updated all statistics fields on locale
+
+  If not transmit project_id field, function will get additional query to Locale
+
+  ## Examples
+
+      iex> update_all_locale_counts(locale_id, project_id)
+
+      iex> update_all_locale_counts(locale_id)
+
+  """
+  def update_all_locale_counts(locale_id, project_id \\ nil) do
+    project_id = unless is_integer(project_id) do
+      project_id = Translations.get_locale!(locale_id).id
+    else
+      project_id
+    end
+
+    Repo.transaction(fn ->
+      total = Projects.get_total_count_of_translation_keys(project_id)
+      verified = calculate_count_of_keys_at_locale_by_status(locale_id, :verified, false)
+      unverified = calculate_count_of_keys_at_locale_by_status(locale_id, :unverified, false)
+      translated = verified + unverified
+      untranslated = total - translated
+
+      from(l in Locale,
+        where: [id: ^locale_id],
+        update: [set: [
+          total_count_of_translation_keys: ^total,
+          count_of_verified_keys: ^verified,
+          count_of_not_verified_keys: ^unverified,
+          count_of_translated_keys: ^translated,
+          count_of_untranslated_keys: ^untranslated
+        ]])
+      |> Repo.update_all([])
+    end)
+  end
+
+  @doc """
+  Async updated all statistics fields on locale
+
+  If not transmit project_id field, function will get additional query to Locale
+
+  ## Examples
+
+      iex> update_all_locale_counts_async(locale_id, project_id)
+
+      iex> update_all_locale_counts_async(locale_id)
+
+  """
+  def update_all_locale_counts_async(locale_id, project_id \\ nil) do
+    spawn(I18NAPI.Translations.Statistics, :update_all_locale_counts, [locale_id, project_id])
+  end
+
+  def calculate_count_of_keys_at_all_locales_for_project_by_status(project_id, status, is_removed \\ false) do
+    from(
+      p in Project,
+      where: [project_id: ^project_id],
+      where: [status: ^status],
+      where: [is_removed: ^is_removed],
+      select: count(t.id)
+    )
+    |> Repo.one!()
+  end
+
+  def update_all_project_counts(project_id) do
+    Repo.transaction(fn ->
+      total = calculate_total_count_of_translation_keys_at_project(project_id, false)
+      # verified = calculate_count_of_keys_at_ ALL LOCALES(project_id, :verified)
+      # unverified = calculate_count_of_keys_at ALL LOCALES(project_id, :unverified)
+      # translated = verified + unverified
+      # untranslated = total - translated
+
+      from(p in Project,
+        where: [id: ^project_id],
+        update: [set: [
+          total_count_of_translation_keys: ^total
+          #count_of_verified_keys: ^verified,
+          #count_of_not_verified_keys: ^unverified,
+          #count_of_translated_keys: ^translated,
+          #count_of_untranslated_keys: ^untranslated
+        ]])
+      |> Repo.update_all([])
+    end)
+  end
+
 
 end

--- a/lib/api/translations/statistics.ex
+++ b/lib/api/translations/statistics.ex
@@ -1,0 +1,66 @@
+defmodule I18NAPI.Translations.Statistics do
+  @moduledoc """
+  The Translations context.
+  """
+  import Ecto.Query, warn: false
+  alias I18NAPI.Repo
+  alias I18NAPI.Utilites
+  alias I18NAPI.Projects
+  alias I18NAPI.Projects.Project
+  alias I18NAPI.Translations.Locale
+  alias I18NAPI.Translations.Translation
+
+  @doc """
+  Inc/decrement a project field :total_count_of_translation_keys.
+
+  ## Examples
+
+      iex> update_total_count_of_translation_keys(project_id)
+      {:ok, %Project{}}
+
+      iex> update_total_count_of_translation_keys(project_id, :dec)
+      {:ok, %Project{}}
+
+  """
+  def update_total_count_of_translation_keys(project_id, operation, value \\ 1)
+  def update_total_count_of_translation_keys(project_id, operation, value)
+      when ((:inc == operation) or (:dec == operation)) and is_integer(value) do
+    if (:dec == operation), do: value = -value
+
+    Task.async(fn ->
+      query = from(p in Project, where: [id: ^project_id])
+      Repo.update_all(query, inc: [total_count_of_translation_keys: value])
+    end)
+  end
+
+  def recalculate_count_of_untranslated_keys_at_locales(project_id) do
+    Task.async(fn ->
+      Repo.transaction(fn ->
+        total = Projects.get_total_count_of_translation_keys(project_id)
+
+        from(l in Locale, where: [project_id: ^project_id],
+        update: [set: [count_of_untranslated_keys: fragment("(? - ?)", ^total, l.count_of_translated_keys)]])
+        |> Repo.update_all([])
+
+      end)
+    end)
+  end
+
+  def update_count_of_keys_at_locales(locale_id, operation, key, value \\ 1)
+  def update_count_of_keys_at_locales(locale_id, operation, key, value)
+      when ((:inc == operation) or (:dec == operation))
+           and is_integer(value) do
+    if (:dec == operation), do: value = -value
+    query = from(l in Locale, where: [id: ^locale_id])
+
+    Task.async(fn ->
+      case key do
+        :translated   -> Repo.update_all(query, set: [count_of_translated_keys: value])
+        :verified     -> Repo.update_all(query, set: [count_of_verified_keys: value])
+        :not_verified -> Repo.update_all(query, set: [count_of_not_verified_keys: value])
+        :need_check   -> Repo.update_all(query, set: [count_of_keys_need_check: value])
+      end
+    end)
+  end
+
+end

--- a/lib/api/translations/statistics.ex
+++ b/lib/api/translations/statistics.ex
@@ -66,69 +66,66 @@ defmodule I18NAPI.Translations.Statistics do
 
   def update_count_choice(locale_id, prev_status, new_status) do
     case {prev_status, new_status} do
-      {:empty, :unverified} -> fn ->
+      {:empty, :unverified} ->
         update_count_of_keys_at_locales(locale_id, :inc, :translated)
         update_count_of_keys_at_locales(locale_id, :dec, :untranslated)
         update_count_of_keys_at_locales(locale_id, :inc, :not_verified)
-                               end
-      {:empty, :verified} -> fn ->
+
+      {:empty, :verified} ->
         update_count_of_keys_at_locales(locale_id, :inc, :translated)
         update_count_of_keys_at_locales(locale_id, :dec, :untranslated)
         update_count_of_keys_at_locales(locale_id, :inc, :verified)
-                             end
-      {:empty, :need_check} -> fn ->
+
+      {:empty, :need_check} ->
         update_count_of_keys_at_locales(locale_id, :inc, :untranslated)
         update_count_of_keys_at_locales(locale_id, :inc, :need_check)
-                               end
 
       {:unverified, :empty} -> fn ->
         update_count_of_keys_at_locales(locale_id, :dec, :translated)
         update_count_of_keys_at_locales(locale_id, :inc, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :not_verified)
-                               end
-      {:unverified, :verified} -> fn ->
+
+      {:unverified, :verified} ->
         update_count_of_keys_at_locales(locale_id, :dec, :not_verified)
         update_count_of_keys_at_locales(locale_id, :inc, :verified)
-                                  end
-      {:unverified, :need_check} -> fn ->
+
+      {:unverified, :need_check} ->
         update_count_of_keys_at_locales(locale_id, :dec, :translated)
         update_count_of_keys_at_locales(locale_id, :inc, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :not_verified)
         update_count_of_keys_at_locales(locale_id, :inc, :need_check)
-                                    end
 
       {:verified, :empty} -> fn ->
         update_count_of_keys_at_locales(locale_id, :dec, :translated)
         update_count_of_keys_at_locales(locale_id, :inc, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :verified)
-                             end
-      {:verified, :unverified} -> fn ->
+
+      {:verified, :unverified} ->
         update_count_of_keys_at_locales(locale_id, :dec, :not_verified)
         update_count_of_keys_at_locales(locale_id, :inc, :verified)
-                                  end
-      {:verified, :need_check} -> fn ->
+
+      {:verified, :need_check} ->
         update_count_of_keys_at_locales(locale_id, :dec, :translated)
         update_count_of_keys_at_locales(locale_id, :inc, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :verified)
         update_count_of_keys_at_locales(locale_id, :inc, :need_check)
-                                  end
 
       {:need_check, :empty} -> fn ->
         update_count_of_keys_at_locales(locale_id, :dec, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :need_check)
-                               end
-      {:need_check, :verified} -> fn ->
+
+      {:need_check, :verified} ->
         update_count_of_keys_at_locales(locale_id, :inc, :translated)
         update_count_of_keys_at_locales(locale_id, :dec, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :need_check)
         update_count_of_keys_at_locales(locale_id, :inc, :verified)
-                                  end
-      {:need_check, :unverified} -> fn ->
+
+      {:need_check, :unverified} ->
         update_count_of_keys_at_locales(locale_id, :inc, :translated)
         update_count_of_keys_at_locales(locale_id, :dec, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :need_check)
         update_count_of_keys_at_locales(locale_id, :inc, :not_verified)
-                                    end
+
     end
   end
 

--- a/lib/api/translations/statistics.ex
+++ b/lib/api/translations/statistics.ex
@@ -25,7 +25,11 @@ defmodule I18NAPI.Translations.Statistics do
   def update_total_count_of_translation_keys(project_id, operation, value \\ 1)
   def update_total_count_of_translation_keys(project_id, operation, value)
       when ((:inc == operation) or (:dec == operation)) and is_integer(value) do
-    if (:dec == operation), do: value = -value
+
+    value = case operation do
+      :inc ->  value
+      :dec -> -value
+    end
 
       query = from(p in Project, where: [id: ^project_id])
       Repo.update_all(query, inc: [total_count_of_translation_keys: value])
@@ -67,7 +71,11 @@ defmodule I18NAPI.Translations.Statistics do
       when ((:inc == operation) or (:dec == operation))
            and is_integer(value) do
 
-    if (:dec == operation), do: value = -value
+    value = case operation do
+      :inc ->  value
+      :dec -> -value
+    end
+
     query = from(l in Locale, where: [id: ^locale_id])
 
       case key do

--- a/lib/api/translations/statistics.ex
+++ b/lib/api/translations/statistics.ex
@@ -62,5 +62,25 @@ defmodule I18NAPI.Translations.Statistics do
       end
     end)
   end
+#:empty, :unverified, :verified, :need_check
+  def update_key_choice(locale_id, prev_key, new_key) do
+    case {prev_key, next_key} do
+      {:empty, :unverified} -> update_count_of_keys_at_locales(locale_id, operation, key)
+      {:empty, :verified} -> update_count_of_keys_at_locales(locale_id, operation, key)
+      {:empty, :need_check} -> update_count_of_keys_at_locales(locale_id, operation, key)
+
+      {:unverified, :empty} -> update_count_of_keys_at_locales(locale_id, operation, key)
+      {:unverified, :verified} -> update_count_of_keys_at_locales(locale_id, operation, key)
+      {:unverified, :need_check} -> update_count_of_keys_at_locales(locale_id, operation, key)
+
+      {:verified, :empty} -> update_count_of_keys_at_locales(locale_id, operation, key)
+      {:verified, :unverified} -> update_count_of_keys_at_locales(locale_id, operation, key)
+      {:verified, :need_check} -> update_count_of_keys_at_locales(locale_id, operation, key)
+
+      {:need_check, :empty} -> update_count_of_keys_at_locales(locale_id, operation, key)
+      {:need_check, :verified} -> update_count_of_keys_at_locales(locale_id, operation, key)
+      {:need_check, :unverified} -> update_count_of_keys_at_locales(locale_id, operation, key)
+    end
+  end
 
 end

--- a/lib/api/translations/statistics.ex
+++ b/lib/api/translations/statistics.ex
@@ -62,24 +62,62 @@ defmodule I18NAPI.Translations.Statistics do
       end
     end)
   end
-#:empty, :unverified, :verified, :need_check
+
   def update_key_choice(locale_id, prev_key, new_key) do
-    case {prev_key, next_key} do
-      {:empty, :unverified} -> update_count_of_keys_at_locales(locale_id, operation, key)
-      {:empty, :verified} -> update_count_of_keys_at_locales(locale_id, operation, key)
-      {:empty, :need_check} -> update_count_of_keys_at_locales(locale_id, operation, key)
+    case {prev_key, new_key} do
+      {:empty, :unverified} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :inc, :translated)
+        update_count_of_keys_at_locales(locale_id, :inc, :not_verified)
+                               end
+      {:empty, :verified} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :inc, :translated)
+        update_count_of_keys_at_locales(locale_id, :inc, :verified)
+                             end
+      {:empty, :need_check} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :inc, :need_check)
+                               end
 
-      {:unverified, :empty} -> update_count_of_keys_at_locales(locale_id, operation, key)
-      {:unverified, :verified} -> update_count_of_keys_at_locales(locale_id, operation, key)
-      {:unverified, :need_check} -> update_count_of_keys_at_locales(locale_id, operation, key)
+      {:unverified, :empty} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :dec, :translated)
+        update_count_of_keys_at_locales(locale_id, :dec, :not_verified)
+                               end
+      {:unverified, :verified} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :dec, :not_verified)
+        update_count_of_keys_at_locales(locale_id, :inc, :verified)
+                                  end
+      {:unverified, :need_check} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :dec, :translated)
+        update_count_of_keys_at_locales(locale_id, :dec, :not_verified)
+        update_count_of_keys_at_locales(locale_id, :inc, :need_check)
+                                    end
 
-      {:verified, :empty} -> update_count_of_keys_at_locales(locale_id, operation, key)
-      {:verified, :unverified} -> update_count_of_keys_at_locales(locale_id, operation, key)
-      {:verified, :need_check} -> update_count_of_keys_at_locales(locale_id, operation, key)
+      {:verified, :empty} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :dec, :translated)
+        update_count_of_keys_at_locales(locale_id, :dec, :verified)
+                             end
+      {:verified, :unverified} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :dec, :not_verified)
+        update_count_of_keys_at_locales(locale_id, :inc, :verified)
+                                  end
+      {:verified, :need_check} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :dec, :translated)
+        update_count_of_keys_at_locales(locale_id, :dec, :verified)
+        update_count_of_keys_at_locales(locale_id, :inc, :need_check)
+                                  end
 
-      {:need_check, :empty} -> update_count_of_keys_at_locales(locale_id, operation, key)
-      {:need_check, :verified} -> update_count_of_keys_at_locales(locale_id, operation, key)
-      {:need_check, :unverified} -> update_count_of_keys_at_locales(locale_id, operation, key)
+      {:need_check, :empty} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :dec, :need_check)
+                               end
+      {:need_check, :verified} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :dec, :need_check)
+        update_count_of_keys_at_locales(locale_id, :inc, :verified)
+        update_count_of_keys_at_locales(locale_id, :inc, :translated)
+                                  end
+      {:need_check, :unverified} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :dec, :need_check)
+        update_count_of_keys_at_locales(locale_id, :inc, :not_verified)
+        update_count_of_keys_at_locales(locale_id, :inc, :translated)
+                                    end
     end
   end
 

--- a/lib/api/translations/statistics.ex
+++ b/lib/api/translations/statistics.ex
@@ -55,10 +55,10 @@ defmodule I18NAPI.Translations.Statistics do
 
     Task.async(fn ->
       case key do
-        :translated   -> Repo.update_all(query, set: [count_of_translated_keys: value])
-        :verified     -> Repo.update_all(query, set: [count_of_verified_keys: value])
-        :not_verified -> Repo.update_all(query, set: [count_of_not_verified_keys: value])
-        :need_check   -> Repo.update_all(query, set: [count_of_keys_need_check: value])
+        :translated   -> Repo.update_all(query, inc: [count_of_translated_keys: value])
+        :verified     -> Repo.update_all(query, inc: [count_of_verified_keys: value])
+        :not_verified -> Repo.update_all(query, inc: [count_of_not_verified_keys: value])
+        :need_check   -> Repo.update_all(query, inc: [count_of_keys_need_check: value])
       end
     end)
   end

--- a/lib/api/translations/statistics.ex
+++ b/lib/api/translations/statistics.ex
@@ -56,6 +56,7 @@ defmodule I18NAPI.Translations.Statistics do
     Task.async(fn ->
       case key do
         :translated   -> Repo.update_all(query, inc: [count_of_translated_keys: value])
+        :untranslated -> Repo.update_all(query, inc: [count_of_untranslated_keys: value])
         :verified     -> Repo.update_all(query, inc: [count_of_verified_keys: value])
         :not_verified -> Repo.update_all(query, inc: [count_of_not_verified_keys: value])
         :need_check   -> Repo.update_all(query, inc: [count_of_keys_need_check: value])
@@ -63,22 +64,26 @@ defmodule I18NAPI.Translations.Statistics do
     end)
   end
 
-  def update_key_choice(locale_id, prev_key, new_key) do
-    case {prev_key, new_key} do
+  def update_count_choice(locale_id, prev_status, new_status) do
+    case {prev_status, new_status} do
       {:empty, :unverified} -> fn ->
         update_count_of_keys_at_locales(locale_id, :inc, :translated)
+        update_count_of_keys_at_locales(locale_id, :dec, :untranslated)
         update_count_of_keys_at_locales(locale_id, :inc, :not_verified)
                                end
       {:empty, :verified} -> fn ->
         update_count_of_keys_at_locales(locale_id, :inc, :translated)
+        update_count_of_keys_at_locales(locale_id, :dec, :untranslated)
         update_count_of_keys_at_locales(locale_id, :inc, :verified)
                              end
       {:empty, :need_check} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :inc, :untranslated)
         update_count_of_keys_at_locales(locale_id, :inc, :need_check)
                                end
 
       {:unverified, :empty} -> fn ->
         update_count_of_keys_at_locales(locale_id, :dec, :translated)
+        update_count_of_keys_at_locales(locale_id, :inc, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :not_verified)
                                end
       {:unverified, :verified} -> fn ->
@@ -87,12 +92,14 @@ defmodule I18NAPI.Translations.Statistics do
                                   end
       {:unverified, :need_check} -> fn ->
         update_count_of_keys_at_locales(locale_id, :dec, :translated)
+        update_count_of_keys_at_locales(locale_id, :inc, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :not_verified)
         update_count_of_keys_at_locales(locale_id, :inc, :need_check)
                                     end
 
       {:verified, :empty} -> fn ->
         update_count_of_keys_at_locales(locale_id, :dec, :translated)
+        update_count_of_keys_at_locales(locale_id, :inc, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :verified)
                              end
       {:verified, :unverified} -> fn ->
@@ -101,22 +108,26 @@ defmodule I18NAPI.Translations.Statistics do
                                   end
       {:verified, :need_check} -> fn ->
         update_count_of_keys_at_locales(locale_id, :dec, :translated)
+        update_count_of_keys_at_locales(locale_id, :inc, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :verified)
         update_count_of_keys_at_locales(locale_id, :inc, :need_check)
                                   end
 
       {:need_check, :empty} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :dec, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :need_check)
                                end
       {:need_check, :verified} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :inc, :translated)
+        update_count_of_keys_at_locales(locale_id, :dec, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :need_check)
         update_count_of_keys_at_locales(locale_id, :inc, :verified)
-        update_count_of_keys_at_locales(locale_id, :inc, :translated)
                                   end
       {:need_check, :unverified} -> fn ->
+        update_count_of_keys_at_locales(locale_id, :inc, :translated)
+        update_count_of_keys_at_locales(locale_id, :dec, :untranslated)
         update_count_of_keys_at_locales(locale_id, :dec, :need_check)
         update_count_of_keys_at_locales(locale_id, :inc, :not_verified)
-        update_count_of_keys_at_locales(locale_id, :inc, :translated)
                                     end
     end
   end

--- a/lib/api/translations/statistics.ex
+++ b/lib/api/translations/statistics.ex
@@ -31,8 +31,8 @@ defmodule I18NAPI.Translations.Statistics do
       :dec -> -value
     end
 
-      query = from(p in Project, where: [id: ^project_id])
-      Repo.update_all(query, inc: [total_count_of_translation_keys: value])
+    query = from(p in Project, where: [id: ^project_id])
+    Repo.update_all(query, inc: [total_count_of_translation_keys: value])
   end
 
   def update_total_count_of_translation_keys_async(project_id, operation, value \\ 1)

--- a/lib/api/translations/translations.ex
+++ b/lib/api/translations/translations.ex
@@ -252,16 +252,16 @@ defmodule I18NAPI.Translations do
   def create_translation_key(attrs \\ %{}, project_id) do
     attrs = Utilites.key_to_string(attrs)
     changeset = Map.put(attrs, "project_id", project_id) |> Utilites.key_to_atom()
-    responce = %TranslationKey{}
+    response = %TranslationKey{}
     |> TranslationKey.changeset(changeset)
     |> Repo.insert()
     |> create_default_translation()
 
-    with {:ok, translation_key} <- responce do
+    with {:ok, translation_key} <- response do
       Statistics.update_total_count_of_translation_keys(project_id, :inc)
       Statistics.recalculate_count_of_untranslated_keys_at_locales(project_id)
     end
-    responce
+    response
   end
 
   @doc """
@@ -303,11 +303,11 @@ defmodule I18NAPI.Translations do
 
   """
   def update_translation_key(%TranslationKey{} = translation_key, attrs) do
-    responce = translation_key
+    response = translation_key
     |> TranslationKey.changeset(attrs)
     |> Repo.update()
 
-    with {:ok, translation_key} <- responce do
+    with {:ok, translation_key} <- response do
       get_default_translation(translation_key.id)
       |> Translation.changeset(%{value: attrs.default_value})
       |> Repo.update()

--- a/lib/api/translations/translations.ex
+++ b/lib/api/translations/translations.ex
@@ -449,9 +449,15 @@ defmodule I18NAPI.Translations do
   """
   def create_translation(attrs \\ %{status: :empty, is_removed: false}, locale_id) do
     changeset = Map.put(attrs, :locale_id, locale_id) |> Utilites.key_to_atom()
-    %Translation{}
+    response = %Translation{}
     |> Translation.changeset(changeset)
     |> Repo.insert()
+
+    with {:ok, translation} <- response,
+         true <- Map.has_key?(changeset, :status),
+         do: Statistics.update_count_choice(translation.locale_id, :empty, changeset.status)
+
+    response
   end
 
   @doc """

--- a/lib/api/translations/translations.ex
+++ b/lib/api/translations/translations.ex
@@ -258,8 +258,8 @@ defmodule I18NAPI.Translations do
     |> create_default_translation()
 
     with {:ok, translation_key} <- response do
-      Statistics.update_total_count_of_translation_keys(project_id, :inc)
-      Statistics.recalculate_count_of_untranslated_keys_at_locales(project_id)
+      Statistics.update_total_count_of_translation_keys_async(project_id, :inc)
+      Statistics.recalculate_count_of_untranslated_keys_at_locales_async(project_id)
     end
     response
   end
@@ -334,8 +334,8 @@ defmodule I18NAPI.Translations do
     |> Repo.update()
 
     with {:ok, translation_key} <- response do
-      Statistics.update_total_count_of_translation_keys(translation_key.project_id, :dec)
-      Statistics.recalculate_count_of_untranslated_keys_at_locales(translation_key.project_id)
+      Statistics.update_total_count_of_translation_keys_async(translation_key.project_id, :dec)
+      Statistics.recalculate_count_of_untranslated_keys_at_locales_async(translation_key.project_id)
     end
 
     response
@@ -365,8 +365,8 @@ defmodule I18NAPI.Translations do
     |> safely_delete_nested_entities(:translations)
 
     with {:ok, translation_key} <- response do
-      Statistics.update_total_count_of_translation_keys(translation_key.project_id, :dec)
-      Statistics.recalculate_count_of_untranslated_keys_at_locales(translation_key.project_id)
+      Statistics.update_total_count_of_translation_keys_async(translation_key.project_id, :dec)
+      Statistics.recalculate_count_of_untranslated_keys_at_locales_async(translation_key.project_id)
     end
 
     response
@@ -455,7 +455,7 @@ defmodule I18NAPI.Translations do
 
     with {:ok, translation} <- response,
          true <- Map.has_key?(changeset, :status),
-         do: Statistics.update_count_choice(translation.locale_id, :empty, changeset.status)
+         do: Statistics.update_count_choice_async(translation.locale_id, :empty, changeset.status)
 
     response
   end
@@ -482,7 +482,7 @@ defmodule I18NAPI.Translations do
 
     with {:ok, translation} <- result,
          true <- Map.has_key?(attrs, :status),
-         do: Statistics.update_count_choice(translation.locale_id, translation.status, attrs.status)
+         do: Statistics.update_count_choice_async(translation.locale_id, translation.status, attrs.status)
 
     with true <- is_default_locale?(translation.locale_id),
          true <- Map.has_key?(attrs, :value),

--- a/lib/api/translations/translations.ex
+++ b/lib/api/translations/translations.ex
@@ -443,7 +443,11 @@ defmodule I18NAPI.Translations do
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_translation(%Translation{} = translation, attrs) do
+  def update_translation(%Translation{} = translation, attrs \\%{}) do
+    pattern = ["status", "value", :status, :value]
+    attrs = Map.take(attrs, pattern)
+
+    attrs = Utilites.key_to_atom(attrs)
     translation
     |> Translation.changeset(attrs)
     |> Repo.update()

--- a/lib/api/translations/translations.ex
+++ b/lib/api/translations/translations.ex
@@ -451,10 +451,10 @@ defmodule I18NAPI.Translations do
     |> Translation.changeset(attrs)
     |> Repo.update()
 
-    if (is_default_locale?(translation.locale_id)
-        && Map.has_key?(attrs, :value)
-        && (translation.value != attrs.value)),
-       do: change_status_for_all_translation_key(translation.translation_key_id)
+    with true <- is_default_locale?(translation.locale_id),
+         true <- Map.has_key?(attrs, :value),
+         true <- translation.value != attrs.value,
+         do: change_status_for_all_translation_key(translation.translation_key_id)
 
     result
   end

--- a/lib/api/translations/translations.ex
+++ b/lib/api/translations/translations.ex
@@ -6,7 +6,7 @@ defmodule I18NAPI.Translations do
   import Ecto.Query, warn: false
   alias I18NAPI.Repo
   alias I18NAPI.Utilites
-  alias I18NAPI.Projects
+  alias I18NAPI.Translations.Statistics
   alias I18NAPI.Translations.Locale
   alias I18NAPI.Translations.Translation
 
@@ -256,17 +256,10 @@ defmodule I18NAPI.Translations do
     |> create_default_translation()
 
     with {:ok, translation_key} <- responce do
-      Task.async(fn -> Projects.update_total_count_of_translation_keys(project_id) end)
-      Task.async(fn -> update_count_of_untranslated_keys_at_locales(project_id) end)
+      Statistics.update_total_count_of_translation_keys(project_id, :inc)
+      Statistics.recalculate_count_of_untranslated_keys_at_locales(project_id)
     end
     responce
-  end
-
-  def update_count_of_untranslated_keys_at_locales(project_id) do
-    total = Projects.get_total_count_of_translation_keys(project_id)
-
-    from(l in Locale, where: [project_id: ^project_id])
-    |> Repo.update_all(set: [count_of_untranslated_keys: (total - :count_of_untranslated_keys)])
   end
 
   @doc """

--- a/lib/api/translations/translations.ex
+++ b/lib/api/translations/translations.ex
@@ -473,10 +473,9 @@ defmodule I18NAPI.Translations do
       tr in Translation,
       join: lcl in Locale,
       on: lcl.id == tr.locale_id,
-      where: (tr.translation_key_id == ^translation_key_id) and not (lcl.is_default),
-      update: [set: [status: "need_check"]]
+      where: (tr.translation_key_id == ^translation_key_id) and not (lcl.is_default)
     )
-    |> Repo.update_all([])
+    |> Repo.update_all(set: [status: "need_check"])
   end
 
   @doc """

--- a/lib/api/translations/translations.ex
+++ b/lib/api/translations/translations.ex
@@ -9,6 +9,7 @@ defmodule I18NAPI.Translations do
   alias I18NAPI.Translations.Statistics
   alias I18NAPI.Translations.Locale
   alias I18NAPI.Translations.Translation
+  alias I18NAPI.Projects
 
   @doc """
   Returns the list of locales.
@@ -94,6 +95,7 @@ defmodule I18NAPI.Translations do
   def create_locale(attrs, project_id) do
     attrs = Utilites.key_to_string(attrs)
     attrs = Map.put(attrs, "project_id", project_id)
+    attrs = Map.put(attrs, "count_of_untranslated_keys", Projects.get_total_count_of_translation_keys(project_id))
     %Locale{}
     |> Locale.changeset(attrs)
     |> Repo.insert()

--- a/lib/api/translations/translations.ex
+++ b/lib/api/translations/translations.ex
@@ -92,13 +92,19 @@ defmodule I18NAPI.Translations do
       {:error, %Ecto.Changeset{}}
 
   """
+
   def create_locale(attrs, project_id) do
     attrs = Utilites.key_to_string(attrs)
     attrs = Map.put(attrs, "project_id", project_id)
-    attrs = Map.put(attrs, "count_of_untranslated_keys", Projects.get_total_count_of_translation_keys(project_id))
-    %Locale{}
-    |> Locale.changeset(attrs)
-    |> Repo.insert()
+    result = %Locale{}
+             |> Locale.changeset(attrs)
+             |> Repo.insert()
+
+    with {:ok, locale} <- result do
+      Statistics.update_all_locale_counts(locale.id, locale.project_id)
+    end
+
+      result
   end
 
   @doc """

--- a/lib/api/utilites.ex
+++ b/lib/api/utilites.ex
@@ -34,4 +34,7 @@ defmodule I18NAPI.Utilites do
     end)
   end
 
+  def random_string(length) do
+    :crypto.strong_rand_bytes(length) |> Base.url_encode64 |> binary_part(0, length)
+  end
 end

--- a/lib/api/utilites/mailer.ex
+++ b/lib/api/utilites/mailer.ex
@@ -1,0 +1,6 @@
+defmodule I18NAPI.Mailer do
+  @moduledoc false
+
+
+
+  end

--- a/lib/api/utilites/mailer.ex
+++ b/lib/api/utilites/mailer.ex
@@ -1,6 +1,3 @@
 defmodule I18NAPI.Mailer do
-  @moduledoc false
-
-
-
-  end
+  use Swoosh.Mailer, otp_app: :api
+end

--- a/lib/api/utilites/user_email.ex
+++ b/lib/api/utilites/user_email.ex
@@ -1,0 +1,18 @@
+defmodule I18NAPI.UserEmail do
+  use Phoenix.Swoosh, view: I18NAPIWeb.EmailView, layout: {I18NAPIWeb.LayoutView, :email}
+
+  alias I18NAPI.User
+  alias I18NAPI.Accounts.Confirmation
+
+  def create_confirmation_email(user) do
+    new()
+    |> to({user.name, user.email})
+    |> from({"Dr B Banner", "hulk.smash@example.com"})
+    |> subject("i18n confirmation email")
+    |> render_body("confirmation_email.html", %{
+      username: user.name,
+      confirmation_token: user.confirmation_token,
+      confirmation_link: Confirmation.create_confirmation_link(user.confirmation_token)
+    })
+  end
+end

--- a/lib/api/utilites/user_email.ex
+++ b/lib/api/utilites/user_email.ex
@@ -1,7 +1,6 @@
 defmodule I18NAPI.UserEmail do
   use Phoenix.Swoosh, view: I18NAPIWeb.EmailView, layout: {I18NAPIWeb.LayoutView, :email}
 
-  alias I18NAPI.User
   alias I18NAPI.Accounts.Confirmation
 
   def create_confirmation_email(user) do

--- a/lib/api_web/controllers/confirmation_controller.ex
+++ b/lib/api_web/controllers/confirmation_controller.ex
@@ -1,0 +1,21 @@
+defmodule I18NAPIWeb.ConfirmationController do
+  use I18NAPIWeb, :controller
+
+  alias I18NAPI.Accounts
+  alias I18NAPI.Accounts.User
+  alias I18NAPI.Accounts.Confirmation
+
+  action_fallback(I18NAPIWeb.FallbackController)
+
+  def confirm(conn, %{"token" => confirmation_token}) do
+    result =  Confirmation.confirm_user_by_token(confirmation_token)
+    case result do
+      {:ok} -> conn |> put_status(200) |> render("200.json")
+      _ -> conn |> put_status(404) |> render("404.json")
+    end
+  end
+
+  def confirm(_conn, _args) do
+    {:error, :bad_request}
+  end
+end

--- a/lib/api_web/controllers/confirmation_controller.ex
+++ b/lib/api_web/controllers/confirmation_controller.ex
@@ -1,14 +1,13 @@
 defmodule I18NAPIWeb.ConfirmationController do
   use I18NAPIWeb, :controller
 
-  alias I18NAPI.Accounts
-  alias I18NAPI.Accounts.User
   alias I18NAPI.Accounts.Confirmation
 
   action_fallback(I18NAPIWeb.FallbackController)
 
   def confirm(conn, %{"token" => confirmation_token}) do
-    result =  Confirmation.confirm_user_by_token(confirmation_token)
+    result = Confirmation.confirm_user_by_token(confirmation_token)
+
     case result do
       {:ok} -> conn |> put_status(200) |> render("200.json")
       _ -> conn |> put_status(404) |> render("404.json")

--- a/lib/api_web/controllers/locale_controller.ex
+++ b/lib/api_web/controllers/locale_controller.ex
@@ -7,7 +7,7 @@ defmodule I18NAPIWeb.LocaleController do
   action_fallback(I18NAPIWeb.FallbackController)
 
   def index(conn, _params) do
-    locales = Translations.list_locales(conn.params["project_id"])
+    locales = Translations.list_locales(conn.private[:guardian_default_resource].id)
     render(conn, "index.json", locales: locales)
   end
 

--- a/lib/api_web/controllers/locale_controller.ex
+++ b/lib/api_web/controllers/locale_controller.ex
@@ -26,14 +26,20 @@ defmodule I18NAPIWeb.LocaleController do
 
   def show(conn, %{"id" => id}) do
     locale = Translations.get_locale!(id)
-    render(conn, "show.json", locale: locale)
+    case locale.is_removed do
+      false ->render(conn, "show.json", locale: locale)
+      _ -> conn |> put_status(204) |> render("204.json")
+    end
   end
 
   def update(conn, %{"id" => id, "locale" => locale_params}) do
     locale = Translations.get_locale!(id)
 
     with {:ok, %Locale{} = locale} <- Translations.update_locale(locale, locale_params) do
-      render(conn, "show.json", locale: locale)
+      case locale.is_removed do
+        false ->render(conn, "show.json", locale: locale)
+        _ -> conn |> put_status(204) |> render("204.json")
+      end
     end
   end
 
@@ -41,7 +47,10 @@ defmodule I18NAPIWeb.LocaleController do
     locale = Translations.get_locale!(id)
 
     with {:ok, %Locale{} = locale} <- Translations.safely_delete_locale(locale) do
-      render(conn, "show.json", locale: locale)
+      case locale.is_removed do
+        false ->render(conn, "show.json", locale: locale)
+        _ -> conn |> put_status(204) |> render("204.json")
+      end
     end
   end
 

--- a/lib/api_web/controllers/project_controller.ex
+++ b/lib/api_web/controllers/project_controller.ex
@@ -28,8 +28,12 @@ defmodule I18NAPIWeb.ProjectController do
 
   def update(conn, %{"id" => id, "project" => project_params}) do
     project = Projects.get_project!(id)
-
     with {:ok, %Project{} = project} <- Projects.update_project(project, project_params) do
+      IO.puts "----------------------"
+      IO.inspect id
+      IO.inspect project_params
+      IO.inspect project
+      IO.puts "----------------------"
       render(conn, "show.json", project: project)
     end
   end

--- a/lib/api_web/controllers/project_controller.ex
+++ b/lib/api_web/controllers/project_controller.ex
@@ -23,18 +23,19 @@ defmodule I18NAPIWeb.ProjectController do
 
   def show(conn, %{"id" => id}) do
     project = Projects.get_project!(id)
-    render(conn, "show.json", project: project)
+    case project.is_removed do
+      false -> render(conn, "show.json", project: project)
+      _ -> conn |> put_status(204) |> render("204.json")
+    end
   end
 
   def update(conn, %{"id" => id, "project" => project_params}) do
     project = Projects.get_project!(id)
     with {:ok, %Project{} = project} <- Projects.update_project(project, project_params) do
-      IO.puts "----------------------"
-      IO.inspect id
-      IO.inspect project_params
-      IO.inspect project
-      IO.puts "----------------------"
-      render(conn, "show.json", project: project)
+      case project.is_removed do
+        false -> render(conn, "show.json", project: project)
+        _ -> conn |> put_status(204) |> render("204.json")
+      end
     end
   end
 
@@ -42,7 +43,10 @@ defmodule I18NAPIWeb.ProjectController do
     project = Projects.get_project!(id)
 
     with {:ok, %Project{} = project} <- Projects.safely_delete_project(project) do
-      render(conn, "show.json", project: project)
+      case project.is_removed do
+        false -> render(conn, "show.json", project: project)
+        _ -> conn |> put_status(204) |> render("204.json")
+      end
     end
   end
 end

--- a/lib/api_web/router.ex
+++ b/lib/api_web/router.ex
@@ -19,7 +19,7 @@ defmodule I18NAPIWeb.Router do
     pipe_through(:api)
     post("/sign_in", SessionController, :sign_in)
     post("/sign_up", RegistrationController, :sign_up)
-
+    post("/confirm", ConfirmationController, :confirm)
     pipe_through(:authenticated)
     resources("/users", UserController)
 

--- a/lib/api_web/templates/email/confirmation_email.html.eex
+++ b/lib/api_web/templates/email/confirmation_email.html.eex
@@ -1,0 +1,7 @@
+<div>
+  <h1>Dear, <%= @username %>!</h1>
+ <body>
+   <p> Please, use this token for confirm your email <%= @confirmation_token %>
+  <p>or follow this link<a href=<%= @confirmation_link %>><%= @confirmation_link %></a></p>
+ </body>
+</div>

--- a/lib/api_web/templates/layout/email.html.eex
+++ b/lib/api_web/templates/layout/email.html.eex
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title><%= @email.subject %></title>
+  </head>
+  <body>
+    <%= render @view_module, @view_template, assigns %>
+  </body>
+</html>

--- a/lib/api_web/views/confirmation_view.ex
+++ b/lib/api_web/views/confirmation_view.ex
@@ -1,0 +1,13 @@
+defmodule I18NAPIWeb.ConfirmationView do
+  use I18NAPIWeb, :view
+  alias I18NAPIWeb.ConfirmationView
+
+  def render("200.json", _) do
+    %{ok: %{detail: "User confirmed"}}
+  end
+
+
+  def render("404.json", _assigns) do
+    %{errors: %{detail: "Not Found"}}
+  end
+end

--- a/lib/api_web/views/confirmation_view.ex
+++ b/lib/api_web/views/confirmation_view.ex
@@ -1,11 +1,9 @@
 defmodule I18NAPIWeb.ConfirmationView do
   use I18NAPIWeb, :view
-  alias I18NAPIWeb.ConfirmationView
 
   def render("200.json", _) do
     %{ok: %{detail: "User confirmed"}}
   end
-
 
   def render("404.json", _assigns) do
     %{errors: %{detail: "Not Found"}}

--- a/lib/api_web/views/email_view.ex
+++ b/lib/api_web/views/email_view.ex
@@ -1,0 +1,3 @@
+defmodule I18NAPIWeb.EmailView do
+  use I18NAPIWeb, :view
+end

--- a/lib/api_web/views/error_view.ex
+++ b/lib/api_web/views/error_view.ex
@@ -10,11 +10,11 @@ defmodule I18NAPIWeb.ErrorView do
   end
 
   def render("404.json", _assigns) do
-    %{errors: %{detail: "Page not found"}}
+    %{errors: %{detail: "Not Found"}}
   end
 
   def render("500.json", _assigns) do
-    %{errors: %{detail: "Internal server error"}}
+    %{errors: %{detail: "Internal Server Error"}}
   end
 
   # By default, Phoenix returns the status message from

--- a/lib/api_web/views/layout_view.ex
+++ b/lib/api_web/views/layout_view.ex
@@ -1,0 +1,3 @@
+defmodule I18NAPIWeb.LayoutView do
+  use I18NAPIWeb, :view
+end

--- a/lib/api_web/views/locale_view.ex
+++ b/lib/api_web/views/locale_view.ex
@@ -12,13 +12,16 @@ defmodule I18NAPIWeb.LocaleView do
 
   def render("locale.json", %{locale: locale}) do
     %{
-      id: locale.id,
+    id: locale.id,
       project_id: locale.project_id,
       locale: locale.locale,
       is_default: locale.is_default,
-      count_of_keys: locale.count_of_keys,
-      count_of_words: locale.count_of_words,
+      total_count_of_translation_keys: locale.total_count_of_translation_keys,
+      count_of_not_verified_keys: locale.count_of_not_verified_keys,
+      count_of_verified_keys: locale.count_of_verified_keys,
       count_of_translated_keys: locale.count_of_translated_keys,
+      count_of_untranslated_keys: locale.count_of_untranslated_keys,
+      count_of_keys_need_check: locale.count_of_keys_need_check,
       is_removed: locale.is_removed,
       removed_at: locale.removed_at
     }
@@ -37,5 +40,9 @@ defmodule I18NAPIWeb.LocaleView do
 
   def render("keys_and_translations.json", %{keys_and_translations: keys_and_translations}) do
     %{data: render_many(keys_and_translations, LocaleView, "key_with_translations.json")}
+  end
+
+  def render("204.json", _) do
+    %{errors: %{detail: "No Content"}}
   end
 end

--- a/lib/api_web/views/project_view.ex
+++ b/lib/api_web/views/project_view.ex
@@ -18,4 +18,8 @@ defmodule I18NAPIWeb.ProjectView do
       removed_at: project.removed_at
     }
   end
+
+  def render("204.json", _) do
+    %{errors: %{detail: "No Content"}}
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,8 @@ defmodule I18NAPI.Mixfile do
       {:comeonin, "~> 4.0"},
       {:bcrypt_elixir, github: "riverrun/bcrypt_elixir", override: true},
       {:ecto_enum, "~> 1.0"},
-      {:guardian, "~> 1.0"}
+      {:guardian, "~> 1.0"},
+      {:swoosh, "~> 0.20"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,8 @@ defmodule I18NAPI.Mixfile do
       {:bcrypt_elixir, github: "riverrun/bcrypt_elixir", override: true},
       {:ecto_enum, "~> 1.0"},
       {:guardian, "~> 1.0"},
-      {:swoosh, "~> 0.20"}
+      {:swoosh, "~> 0.20"},
+      {:phoenix_swoosh, "~> 0.2"}
     ]
   end
 

--- a/priv/repo/migrations/20180407080601_create_projects.exs
+++ b/priv/repo/migrations/20180407080601_create_projects.exs
@@ -7,8 +7,11 @@ defmodule I18NAPI.Repo.Migrations.CreateProjects do
       add :is_removed, :boolean, default: false, null: false
       add :removed_at, :naive_datetime
 
+      add :total_count_of_translation_keys, :integer, default: 0
+
       timestamps()
     end
 
   end
 end
+

--- a/priv/repo/migrations/20180407080601_create_projects.exs
+++ b/priv/repo/migrations/20180407080601_create_projects.exs
@@ -8,6 +8,11 @@ defmodule I18NAPI.Repo.Migrations.CreateProjects do
       add :removed_at, :naive_datetime
 
       add :total_count_of_translation_keys, :integer, default: 0
+      add :count_of_not_verified_keys, :integer, default: 0
+      add :count_of_verified_keys, :integer, default: 0
+      add :count_of_translated_keys, :integer, default: 0
+      add :count_of_untranslated_keys, :integer, default: 0
+      add :count_of_keys_need_check, :integer, default: 0
 
       timestamps()
     end

--- a/priv/repo/migrations/20180407080608_create_user_roles.exs
+++ b/priv/repo/migrations/20180407080608_create_user_roles.exs
@@ -4,8 +4,8 @@ defmodule I18NAPI.Repo.Migrations.CreateUserRoles do
   def change do
     create table(:user_roles) do
       add :role, :integer
-      add :user_id, references(:users, on_delete: :nothing)
-      add :project_id, references(:projects, on_delete: :nothing)
+      add :user_id, references(:users, on_delete: :delete_all)
+      add :project_id, references(:projects, on_delete: :delete_all)
 
       timestamps()
     end

--- a/priv/repo/migrations/20180407080627_create_locales.exs
+++ b/priv/repo/migrations/20180407080627_create_locales.exs
@@ -7,7 +7,7 @@ defmodule I18NAPI.Repo.Migrations.CreateLocales do
       add :is_default, :boolean, default: false, null: false
       add :is_removed, :boolean, default: false, null: false
       add :removed_at, :naive_datetime
-      add :project_id, references(:projects, on_delete: :nothing)
+      add :project_id, references(:projects, on_delete: :delete_all)
 
       add :total_count_of_translation_keys, :integer, default: 0
       add :count_of_not_verified_keys, :integer, default: 0

--- a/priv/repo/migrations/20180407080627_create_locales.exs
+++ b/priv/repo/migrations/20180407080627_create_locales.exs
@@ -9,6 +9,7 @@ defmodule I18NAPI.Repo.Migrations.CreateLocales do
       add :removed_at, :naive_datetime
       add :project_id, references(:projects, on_delete: :nothing)
 
+      add :total_count_of_translation_keys, :integer, default: 0
       add :count_of_not_verified_keys, :integer, default: 0
       add :count_of_verified_keys, :integer, default: 0
       add :count_of_translated_keys, :integer, default: 0

--- a/priv/repo/migrations/20180407080627_create_locales.exs
+++ b/priv/repo/migrations/20180407080627_create_locales.exs
@@ -5,12 +5,15 @@ defmodule I18NAPI.Repo.Migrations.CreateLocales do
     create table(:locales) do
       add :locale, :string
       add :is_default, :boolean, default: false, null: false
-      add :count_of_keys, :integer
-      add :count_of_words, :integer
-      add :count_of_translated_keys, :integer
       add :is_removed, :boolean, default: false, null: false
       add :removed_at, :naive_datetime
       add :project_id, references(:projects, on_delete: :nothing)
+
+      add :count_of_not_verified_keys, :integer, default: 0
+      add :count_of_verified_keys, :integer, default: 0
+      add :count_of_translated_keys, :integer, default: 0
+      add :count_of_untranslated_keys, :integer, default: 0
+      add :count_of_keys_need_check, :integer, default: 0
 
       timestamps()
     end

--- a/priv/repo/migrations/20180407080633_create_user_locales.exs
+++ b/priv/repo/migrations/20180407080633_create_user_locales.exs
@@ -4,8 +4,8 @@ defmodule I18NAPI.Repo.Migrations.CreateUserLocales do
   def change do
     create table(:user_locales) do
       add :role, :integer
-      add :user_id, references(:users, on_delete: :nothing)
-      add :locale_id, references(:locales, on_delete: :nothing)
+      add :user_id, references(:users, on_delete: :delete_all)
+      add :locale_id, references(:locales, on_delete: :delete_all)
 
       timestamps()
     end

--- a/priv/repo/migrations/20180407080639_create_translation_keys.exs
+++ b/priv/repo/migrations/20180407080639_create_translation_keys.exs
@@ -7,7 +7,7 @@ defmodule I18NAPI.Repo.Migrations.CreateTranslationKeys do
       add :context, :text
       add :is_removed, :boolean, default: false, null: false
       add :removed_at, :naive_datetime
-      add :project_id, references(:projects, on_delete: :nothing)
+      add :project_id, references(:projects, on_delete: :delete_all)
 
       timestamps()
     end

--- a/priv/repo/migrations/20180430065646_create_translations.exs
+++ b/priv/repo/migrations/20180430065646_create_translations.exs
@@ -8,8 +8,8 @@ defmodule I18NAPI.Repo.Migrations.CreateTranslations do
       add :is_removed, :boolean, default: false, null: false
       add :removed_at, :naive_datetime
       add :status, TranslationStatusEnum.type()
-      add :locale_id, references(:locales, on_delete: :nothing)
-      add :translation_key_id, references(:translation_keys, on_delete: :nothing)
+      add :locale_id, references(:locales, on_delete: :delete_all)
+      add :translation_key_id, references(:translation_keys, on_delete: :delete_all)
 
       timestamps()
     end

--- a/priv/repo/migrations/20180430065646_create_translations.exs
+++ b/priv/repo/migrations/20180430065646_create_translations.exs
@@ -14,6 +14,6 @@ defmodule I18NAPI.Repo.Migrations.CreateTranslations do
 
     create index(:translations, [:locale_id])
     create index(:translations, [:translation_key_id])
-    create unique_index(:translations, [:locale_id, :translation_key_id, :is_removed])
+    create unique_index(:translations, [:locale_id, :translation_key_id, :is_removed], where: "is_removed = false")
   end
 end

--- a/priv/repo/migrations/20180510082843_add_locales_index_by_removed.exs
+++ b/priv/repo/migrations/20180510082843_add_locales_index_by_removed.exs
@@ -2,7 +2,7 @@ defmodule I18NAPI.Repo.Migrations.AddLocalesIndexByRemoved do
   use Ecto.Migration
 
   def up do
-    create unique_index(:locales, [:project_id, :locale, :is_removed])
+    create unique_index(:locales, [:project_id, :locale, :is_removed], where: "is_removed = false")
     drop_if_exists unique_index(:locales, [:project_id, :locale])
   end
 

--- a/test/api/accounts/accounts_test.exs
+++ b/test/api/accounts/accounts_test.exs
@@ -1,4 +1,7 @@
 defmodule I18NAPI.AccountsTest do
+  use ExUnit.Case, async: true
+  @moduletag :account_api
+
   use I18NAPI.DataCase
 
   alias I18NAPI.Accounts
@@ -7,54 +10,25 @@ defmodule I18NAPI.AccountsTest do
     alias I18NAPI.Accounts.User
 
     @valid_attrs %{
-      confirmation_sent_at: ~N[2010-04-17 14:00:00.000000],
-      confirmation_token: "some confirmation_token",
-      confirmed_at: ~N[2010-04-17 14:00:00.000000],
-      email: "some email",
-      failed_restore_attempts: 42,
-      failed_sign_in_attempts: 42,
-      invited_at: ~N[2010-04-17 14:00:00.000000],
-      is_confirmed: true,
-      last_visited_at: ~N[2010-04-17 14:00:00.000000],
-      name: "some name",
-      password_hash: "some password_hash",
-      restore_accepted_at: ~N[2010-04-17 14:00:00.000000],
-      restore_requested_at: ~N[2010-04-17 14:00:00.000000],
-      restore_token: "some restore_token",
-      source: "some source"
+      name: "test name",
+      email: "test@email.test",
+      password: "Qw!23456",
+      password_confirmation: "Qw!23456",
+      source: "test source"
     }
+
     @update_attrs %{
-      confirmation_sent_at: ~N[2011-05-18 15:01:01.000000],
-      confirmation_token: "some updated confirmation_token",
-      confirmed_at: ~N[2011-05-18 15:01:01.000000],
-      email: "some updated email",
-      failed_restore_attempts: 43,
-      failed_sign_in_attempts: 43,
-      invited_at: ~N[2011-05-18 15:01:01.000000],
-      is_confirmed: false,
-      last_visited_at: ~N[2011-05-18 15:01:01.000000],
-      name: "some updated name",
-      password_hash: "some updated password_hash",
-      restore_accepted_at: ~N[2011-05-18 15:01:01.000000],
-      restore_requested_at: ~N[2011-05-18 15:01:01.000000],
-      restore_token: "some updated restore_token",
-      source: "some updated source"
+      name: "test altername",
+      email: "alter@email.test",
+      password: "Qw!2345678",
+      password_confirmation: "Qw!2345678",
+      source: "alter source"
     }
     @invalid_attrs %{
-      confirmation_sent_at: nil,
-      confirmation_token: nil,
-      confirmed_at: nil,
-      email: nil,
-      failed_restore_attempts: nil,
-      failed_sign_in_attempts: nil,
-      invited_at: nil,
-      is_confirmed: nil,
-      last_visited_at: nil,
       name: nil,
-      password_hash: nil,
-      restore_accepted_at: nil,
-      restore_requested_at: nil,
-      restore_token: nil,
+      email: nil,
+      password: nil,
+      password_confirmation: nil,
       source: nil
     }
 
@@ -68,32 +42,29 @@ defmodule I18NAPI.AccountsTest do
     end
 
     test "list_users/0 returns all users" do
-      user = user_fixture()
-      assert Accounts.list_users() == [user]
+      user_prepared = user_fixture()
+      #      assert Accounts.list_users() == [user_prepared]
+      assert [%User{} | _] = Accounts.list_users()
     end
 
     test "get_user!/1 returns the user with given id" do
-      user = user_fixture()
-      assert Accounts.get_user!(user.id) == user
+      user_prepared = user_fixture()
+      #      assert Accounts.get_user!(user.id) == user
+      assert %User{} = user = Accounts.get_user!(user_prepared.id)
+      assert user.name == user_prepared.name
+      assert user.email == user_prepared.email
+      assert user.password_hash == user_prepared.password_hash
+      assert user.source == user_prepared.source
+      assert user.invited_at == user_prepared.invited_at
     end
 
     test "create_user/1 with valid data creates a user" do
       assert {:ok, %User{} = user} = Accounts.create_user(@valid_attrs)
-      assert user.confirmation_sent_at == ~N[2010-04-17 14:00:00.000000]
-      assert user.confirmation_token == "some confirmation_token"
-      assert user.confirmed_at == ~N[2010-04-17 14:00:00.000000]
-      assert user.email == "some email"
-      assert user.failed_restore_attempts == 42
-      assert user.failed_sign_in_attempts == 42
-      assert user.invited_at == ~N[2010-04-17 14:00:00.000000]
-      assert user.is_confirmed == true
-      assert user.last_visited_at == ~N[2010-04-17 14:00:00.000000]
-      assert user.name == "some name"
-      assert user.password_hash == "some password_hash"
-      assert user.restore_accepted_at == ~N[2010-04-17 14:00:00.000000]
-      assert user.restore_requested_at == ~N[2010-04-17 14:00:00.000000]
-      assert user.restore_token == "some restore_token"
-      assert user.source == "some source"
+      assert user.name == @valid_attrs.name
+      assert user.email == @valid_attrs.email
+      assert user.is_confirmed == false
+      assert user.password_hash =~ ~r/^\$2[ayb]\$.{56}$/
+      assert user.source == @valid_attrs.source
     end
 
     test "create_user/1 with invalid data returns error changeset" do
@@ -101,30 +72,26 @@ defmodule I18NAPI.AccountsTest do
     end
 
     test "update_user/2 with valid data updates the user" do
-      user = user_fixture()
-      assert {:ok, user} = Accounts.update_user(user, @update_attrs)
-      assert %User{} = user
-      assert user.confirmation_sent_at == ~N[2011-05-18 15:01:01.000000]
-      assert user.confirmation_token == "some updated confirmation_token"
-      assert user.confirmed_at == ~N[2011-05-18 15:01:01.000000]
-      assert user.email == "some updated email"
-      assert user.failed_restore_attempts == 43
-      assert user.failed_sign_in_attempts == 43
-      assert user.invited_at == ~N[2011-05-18 15:01:01.000000]
+      user_prepared = user_fixture()
+      assert {:ok, %User{} = user} = Accounts.update_user(user_prepared, @update_attrs)
+      assert user.name == @update_attrs.name
+      assert user.email == @update_attrs.email
       assert user.is_confirmed == false
-      assert user.last_visited_at == ~N[2011-05-18 15:01:01.000000]
-      assert user.name == "some updated name"
-      assert user.password_hash == "some updated password_hash"
-      assert user.restore_accepted_at == ~N[2011-05-18 15:01:01.000000]
-      assert user.restore_requested_at == ~N[2011-05-18 15:01:01.000000]
-      assert user.restore_token == "some updated restore_token"
-      assert user.source == "some updated source"
+      assert user.password_hash =~ ~r/^\$2[ayb]\$.{56}$/
+      assert user.source == @update_attrs.source
+      assert DateTime.from_naive!(user.updated_at, "Etc/UTC") >
+               DateTime.from_naive!(user_prepared.updated_at, "Etc/UTC")
     end
 
     test "update_user/2 with invalid data returns error changeset" do
       user = user_fixture()
       assert {:error, %Ecto.Changeset{}} = Accounts.update_user(user, @invalid_attrs)
-      assert user == Accounts.get_user!(user.id)
+      assert %User{} = user = Accounts.get_user!(user.id)
+      assert user.name == @valid_attrs.name
+      assert user.email == @valid_attrs.email
+      assert user.is_confirmed == false
+      assert user.password_hash =~ ~r/^\$2[ayb]\$.{56}$/
+      assert user.source == @valid_attrs.source
     end
 
     test "delete_user/1 deletes the user" do

--- a/test/api/accounts/accounts_test.exs
+++ b/test/api/accounts/accounts_test.exs
@@ -42,8 +42,7 @@ defmodule I18NAPI.AccountsTest do
     end
 
     test "list_users/0 returns all users" do
-      user_prepared = user_fixture()
-      #      assert Accounts.list_users() == [user_prepared]
+      user_fixture()
       assert [%User{} | _] = Accounts.list_users()
     end
 

--- a/test/api/accounts/confirmation_test.exs
+++ b/test/api/accounts/confirmation_test.exs
@@ -17,25 +17,11 @@ defmodule I18NAPI.ConfirmationTest do
     source: "test source",
   }
 
-  def user_fixture(attrs \\ %{}) do
+  def user_fixture() do
     {:ok, user} = %User{}
-                  |> User.changeset(attrs |> Enum.into(@user_attrs))
-                  |> Repo.insert()
-
-    {:ok, user |> Map.put(:confirmation_token, Utilites.random_string(32))}
-  end
-
-  def unconfirmed_user_fixture(token) do
-    {:ok, user} = user_fixture()
-    attrs = %{
-      confirmation_token: token,
-      confirmed_at: nil,
-      is_confirmed: false
-    }
+    |> User.changeset(Map.put(@user_attrs, :confirmation_token, Utilites.random_string(32)))
+    |> Repo.insert()
     user
-    |> User.confirmation_changeset(attrs)
-    |> Repo.update()
-
   end
 
   describe "confirmation" do
@@ -44,12 +30,10 @@ defmodule I18NAPI.ConfirmationTest do
     end
 
     test"confirm_user_by_token" do
-      token =  Utilites.random_string(32)
-
-      {:ok, user} = unconfirmed_user_fixture(token)
+      user = user_fixture()
       refute user.is_confirmed
 
-      user = with {:ok} <- Confirmation.confirm_user_by_token(token), do:
+      user = with {:ok} <- Confirmation.confirm_user_by_token(user.confirmation_token), do:
         Accounts.get_user!(user.id)
 
       assert user.is_confirmed

--- a/test/api/accounts/confirmation_test.exs
+++ b/test/api/accounts/confirmation_test.exs
@@ -1,0 +1,58 @@
+defmodule I18NAPI.ConfirmationTest do
+  use ExUnit.Case, async: true
+  @moduletag :confirmation_api
+
+  use I18NAPI.DataCase
+
+  alias I18NAPI.Utilites
+  alias I18NAPI.Accounts
+  alias I18NAPI.Accounts.User
+  alias I18NAPI.Accounts.Confirmation
+
+  @user_attrs %{
+    name: "test name",
+    email: "test@email.test",
+    password: "Qw!23456",
+    password_confirmation: "Qw!23456",
+    source: "test source",
+  }
+
+  def user_fixture(attrs \\ %{}) do
+    {:ok, user} = %User{}
+                  |> User.changeset(attrs |> Enum.into(@user_attrs))
+                  |> Repo.insert()
+
+    {:ok, user |> Map.put(:confirmation_token, Utilites.random_string(32))}
+  end
+
+  def unconfirmed_user_fixture(token) do
+    {:ok, user} = user_fixture()
+    attrs = %{
+      confirmation_token: token,
+      confirmed_at: nil,
+      is_confirmed: false
+    }
+    user
+    |> User.confirmation_changeset(attrs)
+    |> Repo.update()
+
+  end
+
+  describe "confirmation" do
+    test "send_confirmation_email" do
+      assert {:ok, %User{}} = Confirmation.send_confirmation_email(user_fixture())
+    end
+
+    test"confirm_user_by_token" do
+      token =  Utilites.random_string(32)
+
+      {:ok, user} = unconfirmed_user_fixture(token)
+      refute user.is_confirmed
+
+      user = with {:ok} <- Confirmation.confirm_user_by_token(token), do:
+        Accounts.get_user!(user.id)
+
+      assert user.is_confirmed
+    end
+  end
+end

--- a/test/api/projects/projects_test.exs
+++ b/test/api/projects/projects_test.exs
@@ -57,11 +57,18 @@ defmodule I18NAPI.ProjectsTest do
       assert Projects.get_project!(project.id) == project
     end
 
+    alias I18NAPI.Translations
+    alias I18NAPI.Projects.UserLocales
     test "create_project/1 with valid data creates a project" do
-      assert {:ok, %Project{} = project} = Projects.create_project(@valid_project_attrs, user_fixture())
+      user = user_fixture()
+      {:ok, project} = Projects.create_project(@valid_project_attrs, user)
+      assert %Project{} = project
       assert project.is_removed == false
       assert project.default_locale == @valid_project_attrs.default_locale
       assert project.total_count_of_translation_keys == 0
+      locale = Translations.get_default_locale!(project.id)
+      user_locale = Projects.get_user_locales!(locale.id, user.id)
+      assert %UserLocales{} = user_locale
     end
 
     test "create_project/1 with invalid data returns error changeset" do

--- a/test/api/projects/projects_test.exs
+++ b/test/api/projects/projects_test.exs
@@ -1,28 +1,48 @@
 defmodule I18NAPI.ProjectsTest do
+  use ExUnit.Case, async: true
+  @moduletag :project_api
+
   use I18NAPI.DataCase
 
   alias I18NAPI.Projects
 
   describe "projects" do
     alias I18NAPI.Projects.Project
+    alias I18NAPI.Accounts
 
+
+    @user_attrs %{
+      name: "test name",
+      email: "test@email.test",
+      password: "Qw!23456",
+      password_confirmation: "Qw!23456",
+      source: "test source"
+    }
+
+    def user_fixture(attrs \\ %{}) do
+      {:ok, user} =
+        attrs
+        |> Enum.into(@user_attrs)
+        |> Accounts.create_user()
+
+      user
+    end
     @valid_attrs %{
-      is_removed: true,
       name: "some name",
-      removed_at: ~N[2010-04-17 14:00:00.000000]
+      default_locale: "en"
     }
     @update_attrs %{
-      is_removed: false,
-      name: "some updated name",
-      removed_at: ~N[2011-05-18 15:01:01.000000]
+      name: "some updated name"
+      #      is_removed: false,
+      #      removed_at: ~N[2011-05-18 15:01:01.000000]
     }
-    @invalid_attrs %{is_removed: nil, name: nil, removed_at: nil}
+    @invalid_attrs %{name: nil, default_locale: nil, is_removed: nil, removed_at: nil}
 
     def project_fixture(attrs \\ %{}) do
       {:ok, project} =
         attrs
         |> Enum.into(@valid_attrs)
-        |> Projects.create_project()
+        |> Projects.create_project(user_fixture())
 
       project
     end
@@ -38,10 +58,9 @@ defmodule I18NAPI.ProjectsTest do
     end
 
     test "create_project/1 with valid data creates a project" do
-      assert {:ok, %Project{} = project} = Projects.create_project(@valid_attrs)
-      assert project.is_removed == true
-      assert project.name == "some name"
-      assert project.removed_at == ~N[2010-04-17 14:00:00.000000]
+      assert {:ok, %Project{} = project} = Projects.create_project(@valid_attrs, user_fixture())
+      assert project.is_removed == false
+      assert project.default_locale == @valid_attrs.default_locale
     end
 
     test "create_project/1 with invalid data returns error changeset" do
@@ -138,8 +157,8 @@ defmodule I18NAPI.ProjectsTest do
   describe "user_locales" do
     alias I18NAPI.Projects.UserLocales
 
-    @valid_attrs %{role: 42}
-    @update_attrs %{role: 43}
+    @valid_attrs %{role: 0}
+    @update_attrs %{role: 1}
     @invalid_attrs %{role: nil}
 
     def user_locales_fixture(attrs \\ %{}) do
@@ -163,7 +182,7 @@ defmodule I18NAPI.ProjectsTest do
 
     test "create_user_locales/1 with valid data creates a user_locales" do
       assert {:ok, %UserLocales{} = user_locales} = Projects.create_user_locales(@valid_attrs)
-      assert user_locales.role == 42
+      assert user_locales.role == 0
     end
 
     test "create_user_locales/1 with invalid data returns error changeset" do
@@ -174,7 +193,7 @@ defmodule I18NAPI.ProjectsTest do
       user_locales = user_locales_fixture()
       assert {:ok, user_locales} = Projects.update_user_locales(user_locales, @update_attrs)
       assert %UserLocales{} = user_locales
-      assert user_locales.role == 43
+      assert user_locales.role == 1
     end
 
     test "update_user_locales/2 with invalid data returns error changeset" do

--- a/test/api/projects/projects_test.exs
+++ b/test/api/projects/projects_test.exs
@@ -3,153 +3,176 @@ defmodule I18NAPI.ProjectsTest do
   @moduletag :project_api
 
   use I18NAPI.DataCase
-
   alias I18NAPI.Projects
+  alias I18NAPI.Projects.Project
+  alias I18NAPI.Accounts
+  alias I18NAPI.Accounts.User
+
+  @user_attrs %{
+    name: "test name",
+    email: "test@email.test",
+    password: "Qw!23456",
+    password_confirmation: "Qw!23456",
+    source: "test source"
+  }
+
+  def user_fixture(attrs \\ %{}) do
+    {:ok, user} =
+      attrs
+      |> Enum.into(@user_attrs)
+      |> Accounts.create_user()
+
+    user
+  end
+
+  @valid_project_attrs %{
+    name: "some name",
+    default_locale: "en"
+  }
+
+  def project_fixture(attrs \\ %{}, %User{} = user) do
+    {:ok, project} =
+      attrs
+      |> Enum.into(@valid_project_attrs)
+      |> Projects.create_project(user)
+
+    project
+  end
 
   describe "projects" do
-    alias I18NAPI.Projects.Project
-    alias I18NAPI.Accounts
 
-
-    @user_attrs %{
-      name: "test name",
-      email: "test@email.test",
-      password: "Qw!23456",
-      password_confirmation: "Qw!23456",
-      source: "test source"
-    }
-
-    def user_fixture(attrs \\ %{}) do
-      {:ok, user} =
-        attrs
-        |> Enum.into(@user_attrs)
-        |> Accounts.create_user()
-
-      user
-    end
-    @valid_attrs %{
-      name: "some name",
-      default_locale: "en"
-    }
-    @update_attrs %{
+    @update_project_attrs %{
       name: "some updated name"
-      #      is_removed: false,
-      #      removed_at: ~N[2011-05-18 15:01:01.000000]
     }
-    @invalid_attrs %{name: nil, default_locale: nil, is_removed: nil, removed_at: nil}
 
-    def project_fixture(attrs \\ %{}) do
-      {:ok, project} =
-        attrs
-        |> Enum.into(@valid_attrs)
-        |> Projects.create_project(user_fixture())
-
-      project
-    end
+    @invalid_project_attrs %{name: nil, default_locale: nil, is_removed: nil, removed_at: nil}
 
     test "list_projects/0 returns all projects" do
-      project = project_fixture()
+      project = project_fixture(%{}, user_fixture())
       assert Projects.list_projects() == [project]
     end
 
     test "get_project!/1 returns the project with given id" do
-      project = project_fixture()
+      project = project_fixture(%{}, user_fixture())
       assert Projects.get_project!(project.id) == project
     end
 
     test "create_project/1 with valid data creates a project" do
-      assert {:ok, %Project{} = project} = Projects.create_project(@valid_attrs, user_fixture())
+      assert {:ok, %Project{} = project} = Projects.create_project(@valid_project_attrs, user_fixture())
       assert project.is_removed == false
-      assert project.default_locale == @valid_attrs.default_locale
+      assert project.default_locale == @valid_project_attrs.default_locale
     end
 
     test "create_project/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Projects.create_project(@invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Projects.create_project(@invalid_project_attrs)
     end
 
     test "update_project/2 with valid data updates the project" do
-      project = project_fixture()
-      assert {:ok, project} = Projects.update_project(project, @update_attrs)
+      project = project_fixture(%{}, user_fixture())
+      assert {:ok, project} = Projects.update_project(project, @update_project_attrs)
       assert %Project{} = project
       assert project.is_removed == false
       assert project.name == "some updated name"
-      assert project.removed_at == ~N[2011-05-18 15:01:01.000000]
     end
 
     test "update_project/2 with invalid data returns error changeset" do
-      project = project_fixture()
-      assert {:error, %Ecto.Changeset{}} = Projects.update_project(project, @invalid_attrs)
+      project = project_fixture(%{}, user_fixture())
+      assert {:error, %Ecto.Changeset{}} = Projects.update_project(project, @invalid_project_attrs)
       assert project == Projects.get_project!(project.id)
     end
 
     test "delete_project/1 deletes the project" do
-      project = project_fixture()
+      project = project_fixture(%{}, user_fixture())
       assert {:ok, %Project{}} = Projects.delete_project(project)
       assert_raise Ecto.NoResultsError, fn -> Projects.get_project!(project.id) end
     end
 
     test "change_project/1 returns a project changeset" do
-      project = project_fixture()
+      project = project_fixture(%{}, user_fixture())
       assert %Ecto.Changeset{} = Projects.change_project(project)
     end
   end
 
   describe "user_roles" do
     alias I18NAPI.Projects.UserRoles
+    alias EctoEnum
 
-    @valid_attrs %{role: 42}
-    @update_attrs %{role: 43}
+    @valid_attrs %{role: :manager}
+    @update_attrs %{role: :translator}
     @invalid_attrs %{role: nil}
 
-    def user_roles_fixture(attrs \\ %{}) do
-      {:ok, user_roles} =
-        attrs
-        |> Enum.into(@valid_attrs)
-        |> Projects.create_user_roles()
+    @user_alter_attrs %{
+      name: "alter name",
+      email: "alter@email.test",
+      password: "Qw!23456",
+      password_confirmation: "Qw!23456",
+      source: "test source"
+    }
 
-      user_roles
+    def user_roles_fixture(attrs \\ %{}, %User{} = user) do
+      project_id = project_fixture(@valid_project_attrs, user).id
+
+      Projects.get_user_roles!(project_id, user.id)
     end
 
     test "list_user_roles/0 returns all user_roles" do
-      user_roles = user_roles_fixture()
+      user_roles = user_roles_fixture(%{}, user_fixture())
       assert Projects.list_user_roles() == [user_roles]
     end
 
     test "get_user_roles!/1 returns the user_roles with given id" do
-      user_roles = user_roles_fixture()
+      user_roles = user_roles_fixture(%{}, user_fixture())
       assert Projects.get_user_roles!(user_roles.id) == user_roles
     end
 
+    test "get_user_roles!/2 returns the user_roles with given id" do
+      user = user_fixture(@user_attrs)
+      project_id = project_fixture(@valid_project_attrs, user).id
+
+      assert %UserRoles{} = Projects.get_user_roles!(project_id, user.id)
+    end
+
     test "create_user_roles/1 with valid data creates a user_roles" do
-      assert {:ok, %UserRoles{} = user_roles} = Projects.create_user_roles(@valid_attrs)
-      assert user_roles.role == 42
+      user = user_fixture(@user_attrs)
+      user_alter = user_fixture(@user_alter_attrs)
+      project_id = project_fixture(@valid_project_attrs, user).id
+      attrs = @valid_attrs
+      # use alternative user because user_role already created on project creating
+      attrs = Map.put(attrs, :user_id, user_alter.id)
+      attrs = Map.put(attrs, :project_id, project_id)
+      assert {:ok, %UserRoles{} = user_roles} = Projects.create_user_roles(attrs)
+      assert user_roles.role == :manager
     end
 
     test "create_user_roles/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Projects.create_user_roles(@invalid_attrs)
+      user = user_fixture()
+      attrs = @invalid_attrs
+      attrs = Map.put(attrs, :user_id, user.id)
+      attrs = Map.put(attrs, :project_id, project_fixture(@valid_project_attrs, user).id)
+      assert {:error, %Ecto.Changeset{}} = Projects.create_user_roles(attrs)
     end
 
     test "update_user_roles/2 with valid data updates the user_roles" do
-      user_roles = user_roles_fixture()
+      user_roles = user_roles_fixture(%{}, user_fixture())
       assert {:ok, user_roles} = Projects.update_user_roles(user_roles, @update_attrs)
       assert %UserRoles{} = user_roles
-      assert user_roles.role == 43
+      assert user_roles.role == :translator
     end
 
     test "update_user_roles/2 with invalid data returns error changeset" do
-      user_roles = user_roles_fixture()
+      user_roles = user_roles_fixture(%{}, user_fixture())
       assert {:error, %Ecto.Changeset{}} = Projects.update_user_roles(user_roles, @invalid_attrs)
       assert user_roles == Projects.get_user_roles!(user_roles.id)
     end
 
     test "delete_user_roles/1 deletes the user_roles" do
-      user_roles = user_roles_fixture()
+      user_roles = user_roles_fixture(%{}, user_fixture())
       assert {:ok, %UserRoles{}} = Projects.delete_user_roles(user_roles)
       assert_raise Ecto.NoResultsError, fn -> Projects.get_user_roles!(user_roles.id) end
     end
 
     test "change_user_roles/1 returns a user_roles changeset" do
-      user_roles = user_roles_fixture()
+      user_roles = user_roles_fixture(%{}, user_fixture())
       assert %Ecto.Changeset{} = Projects.change_user_roles(user_roles)
     end
   end

--- a/test/api/projects/projects_test.exs
+++ b/test/api/projects/projects_test.exs
@@ -118,18 +118,18 @@ defmodule I18NAPI.ProjectsTest do
     }
 
     def user_roles_fixture(attrs \\ %{}, %User{} = user) do
-      project_id = project_fixture(@valid_project_attrs, user).id
+      project_id = project_fixture(attrs, user).id
 
       Projects.get_user_roles!(project_id, user.id)
     end
 
     test "list_user_roles/0 returns all user_roles" do
-      user_roles = user_roles_fixture(%{}, user_fixture())
+      user_roles = user_roles_fixture(@valid_project_attrs, user_fixture())
       assert Projects.list_user_roles() == [user_roles]
     end
 
     test "get_user_roles!/1 returns the user_roles with given id" do
-      user_roles = user_roles_fixture(%{}, user_fixture())
+      user_roles = user_roles_fixture(@valid_project_attrs, user_fixture())
       assert Projects.get_user_roles!(user_roles.id) == user_roles
     end
 
@@ -161,26 +161,26 @@ defmodule I18NAPI.ProjectsTest do
     end
 
     test "update_user_roles/2 with valid data updates the user_roles" do
-      user_roles = user_roles_fixture(%{}, user_fixture())
+      user_roles = user_roles_fixture(@valid_project_attrs, user_fixture())
       assert {:ok, user_roles} = Projects.update_user_roles(user_roles, @update_attrs)
       assert %UserRoles{} = user_roles
       assert user_roles.role == :translator
     end
 
     test "update_user_roles/2 with invalid data returns error changeset" do
-      user_roles = user_roles_fixture(%{}, user_fixture())
+      user_roles = user_roles_fixture(@valid_project_attrs, user_fixture())
       assert {:error, %Ecto.Changeset{}} = Projects.update_user_roles(user_roles, @invalid_attrs)
       assert user_roles == Projects.get_user_roles!(user_roles.id)
     end
 
     test "delete_user_roles/1 deletes the user_roles" do
-      user_roles = user_roles_fixture(%{}, user_fixture())
+      user_roles = user_roles_fixture(@valid_project_attrs, user_fixture())
       assert {:ok, %UserRoles{}} = Projects.delete_user_roles(user_roles)
       assert_raise Ecto.NoResultsError, fn -> Projects.get_user_roles!(user_roles.id) end
     end
 
     test "change_user_roles/1 returns a user_roles changeset" do
-      user_roles = user_roles_fixture(%{}, user_fixture())
+      user_roles = user_roles_fixture(@valid_project_attrs, user_fixture())
       assert %Ecto.Changeset{} = Projects.change_user_roles(user_roles)
     end
   end

--- a/test/api/projects/projects_test.exs
+++ b/test/api/projects/projects_test.exs
@@ -61,6 +61,7 @@ defmodule I18NAPI.ProjectsTest do
       assert {:ok, %Project{} = project} = Projects.create_project(@valid_project_attrs, user_fixture())
       assert project.is_removed == false
       assert project.default_locale == @valid_project_attrs.default_locale
+      assert project.total_count_of_translation_keys == 0
     end
 
     test "create_project/1 with invalid data returns error changeset" do

--- a/test/api/translations/statistics_test.exs
+++ b/test/api/translations/statistics_test.exs
@@ -153,6 +153,9 @@ defmodule I18NAPI.StatisticsTest do
       assert locale.count_of_verified_keys == 0
       assert locale.count_of_translated_keys == 0
       assert locale.count_of_untranslated_keys == 0
+
+      project = Projects.get_project!(project.id)
+
       Statistics.update_all_project_counts(project.id)
       Statistics.update_all_locale_counts(locale.id, project.id)
       locale = Translations.get_locale!(locale.id)

--- a/test/api/translations/statistics_test.exs
+++ b/test/api/translations/statistics_test.exs
@@ -1,0 +1,116 @@
+defmodule I18NAPI.TranslationsTest do
+  use ExUnit.Case, async: true
+  @moduletag :statistics_api
+
+  use I18NAPI.DataCase
+  alias I18NAPI.Translations
+  alias I18NAPI.Translations.Statistics
+  alias I18NAPI.Accounts
+  alias I18NAPI.Accounts.User
+  alias I18NAPI.Projects
+  alias I18NAPI.Projects.Project
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(I18NAPI.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(I18NAPI.Repo, {:shared, self()})
+    :ok
+  end
+
+  @user_attrs %{
+    name: "test name",
+    email: "test@email.test",
+    password: "Qw!23456",
+    password_confirmation: "Qw!23456",
+    source: "test source"
+  }
+
+  def user_fixture(attrs \\ %{}) do
+    {:ok, user} =
+      attrs
+      |> Enum.into(@user_attrs)
+      |> Accounts.create_user()
+
+    user
+  end
+
+  @valid_project_attrs %{
+    name: "some name",
+    default_locale: "en"
+  }
+
+  def project_fixture(attrs \\ %{}, %User{} = user) do
+    {:ok, project} =
+      attrs
+      |> Enum.into(@valid_project_attrs)
+      |> Projects.create_project(user)
+
+    project
+  end
+
+  describe "total_count_of_translation_keys" do
+    test "update_total_count_of_translation_keys/2 with increment operation" do
+      project = project_fixture(%{}, user_fixture())
+      assert project.total_count_of_translation_keys == 0
+
+      Task.await(
+        Statistics.update_total_count_of_translation_keys(project.id, :inc)
+      )
+
+      project = Projects.get_project!(project.id)
+      assert project.total_count_of_translation_keys == 1
+    end
+
+    test "update_total_count_of_translation_keys/2 with decrement operation" do
+      project = project_fixture(%{}, user_fixture())
+      assert project.total_count_of_translation_keys == 0
+
+      Task.await(
+        Statistics.update_total_count_of_translation_keys(project.id, :inc)
+      )
+      Task.await(
+        Statistics.update_total_count_of_translation_keys(project.id, :dec)
+      )
+
+      project = Projects.get_project!(project.id)
+      assert project.total_count_of_translation_keys == 0
+    end
+
+  end
+
+  describe "count_of_keys_at_locales" do
+    @valid_locale_attrs %{
+      locale: "some locale",
+      status: 0,
+      is_default: true
+    }
+
+    def locale_fixture(attrs \\ %{}, project_id) do
+      {:ok, locale} =
+        attrs
+        |> Enum.into(@valid_locale_attrs)
+        |> Translations.create_locale(project_id)
+
+      locale
+    end
+
+    test "recalculate_count_of_untranslated_keys_at_locales/1 when " do
+      project = project_fixture(%{}, user_fixture())
+      Task.await(
+        Statistics.update_total_count_of_translation_keys(project.id, :inc, 5)
+      )
+      locale = locale_fixture(project.id)
+
+      Task.await(
+        Statistics.update_count_of_keys_at_locales(locale.id, :inc, :translated, 3)
+      )
+
+      Task.await(
+        Statistics.recalculate_count_of_untranslated_keys_at_locales(project.id)
+      )
+      locale = Translations.get_locale!(locale.id)
+      assert locale.count_of_untranslated_keys == 2
+    end
+
+  end
+
+end

--- a/test/api/translations/statistics_test.exs
+++ b/test/api/translations/statistics_test.exs
@@ -3,7 +3,6 @@ defmodule I18NAPI.StatisticsTest do
   @moduletag :statistics_api
 
   use I18NAPI.DataCase
-  import Mox
   alias I18NAPI.Translations
   alias I18NAPI.Translations.Statistics
   alias I18NAPI.Accounts
@@ -130,7 +129,7 @@ defmodule I18NAPI.StatisticsTest do
       translation
     end
 
-    test "++++++++++++++++++++++++++calculate count of verified and unverified keys at locale" do
+    test "calculate count of verified and unverified keys at locale" do
       project = project_fixture(%{}, user_fixture())
       locale = Translations.get_default_locale!(project.id)
       translation_key = translation_key_fixture(@valid_translation_key_attrs, project.id)
@@ -143,7 +142,7 @@ defmodule I18NAPI.StatisticsTest do
       assert co_unverified_k == 2
     end
 
-    test "____________________update counts at locale" do
+    test "update counts at locale" do
       project = project_fixture(%{}, user_fixture())
       locale = Translations.get_default_locale!(project.id)
       translation_key = translation_key_fixture(@valid_translation_key_attrs, project.id)

--- a/test/api/translations/statistics_test.exs
+++ b/test/api/translations/statistics_test.exs
@@ -1,4 +1,4 @@
-defmodule I18NAPI.TranslationsTest do
+defmodule I18NAPI.StatisticsTest do
   use ExUnit.Case, async: true
   @moduletag :statistics_api
 
@@ -103,12 +103,109 @@ defmodule I18NAPI.TranslationsTest do
       Task.await(
         Statistics.update_count_of_keys_at_locales(locale.id, :inc, :translated, 3)
       )
+      assert locale.count_of_untranslated_keys == 0
 
       Task.await(
         Statistics.recalculate_count_of_untranslated_keys_at_locales(project.id)
       )
       locale = Translations.get_locale!(locale.id)
       assert locale.count_of_untranslated_keys == 2
+    end
+
+    test "update_count_of_keys_at_locales/3 increment and decrement for :count_of_translated_keys" do
+      project = project_fixture(%{}, user_fixture())
+      locale = locale_fixture(project.id)
+
+      assert locale.count_of_translated_keys == 0
+      Task.await(
+        Statistics.update_count_of_keys_at_locales(locale.id, :inc, :translated)
+      )
+
+      locale = Translations.get_locale!(locale.id)
+      assert locale.count_of_translated_keys == 1
+
+      Task.await(
+        Statistics.update_count_of_keys_at_locales(locale.id, :dec, :translated)
+      )
+
+      locale = Translations.get_locale!(locale.id)
+      assert locale.count_of_translated_keys == 0
+    end
+
+    test "update_count_of_keys_at_locales/4 increment and decrement for :count_of_translated_keys" do
+      project = project_fixture(%{}, user_fixture())
+      locale = locale_fixture(project.id)
+
+      assert locale.count_of_translated_keys == 0
+      Task.await(
+        Statistics.update_count_of_keys_at_locales(locale.id, :inc, :translated, 4)
+      )
+
+      locale = Translations.get_locale!(locale.id)
+      assert locale.count_of_translated_keys == 4
+      Task.await(
+        Statistics.update_count_of_keys_at_locales(locale.id, :dec, :translated, 2)
+      )
+
+      locale = Translations.get_locale!(locale.id)
+      assert locale.count_of_translated_keys == 2
+    end
+
+    test "update_count_of_keys_at_locales/4 increment and decrement for :count_of_verified_keys" do
+      project = project_fixture(%{}, user_fixture())
+      locale = locale_fixture(project.id)
+
+      assert locale.count_of_verified_keys == 0
+      Task.await(
+        Statistics.update_count_of_keys_at_locales(locale.id, :inc, :verified, 4)
+      )
+
+      locale = Translations.get_locale!(locale.id)
+      assert locale.count_of_verified_keys == 4
+      Task.await(
+        Statistics.update_count_of_keys_at_locales(locale.id, :dec, :verified, 2)
+      )
+
+      locale = Translations.get_locale!(locale.id)
+      assert locale.count_of_verified_keys == 2
+    end
+
+    test "update_count_of_keys_at_locales/4 increment and decrement for :count_of_not_verified_keys" do
+      project = project_fixture(%{}, user_fixture())
+      locale = locale_fixture(project.id)
+
+      assert locale.count_of_not_verified_keys == 0
+      Task.await(
+        Statistics.update_count_of_keys_at_locales(locale.id, :inc, :not_verified, 4)
+      )
+
+      locale = Translations.get_locale!(locale.id)
+      assert locale.count_of_not_verified_keys == 4
+      Task.await(
+        Statistics.update_count_of_keys_at_locales(locale.id, :dec, :not_verified, 2)
+      )
+
+      locale = Translations.get_locale!(locale.id)
+      assert locale.count_of_not_verified_keys == 2
+    end
+
+    test "update_count_of_keys_at_locales/4 increment and decrement for :count_of_keys_need_check" do
+      project = project_fixture(%{}, user_fixture())
+      locale = locale_fixture(project.id)
+
+      assert locale.count_of_keys_need_check == 0
+      Task.await(
+        Statistics.update_count_of_keys_at_locales(locale.id, :inc, :need_check, 4)
+      )
+
+      locale = Translations.get_locale!(locale.id)
+      assert locale.count_of_keys_need_check == 4
+      Task.await(
+        Statistics.update_count_of_keys_at_locales(locale.id, :dec, :need_check, 2)
+      )
+
+      locale = Translations.get_locale!(locale.id)
+      assert locale.count_of_keys_need_check == 2
     end
 
   end

--- a/test/api/translations/statistics_test.exs
+++ b/test/api/translations/statistics_test.exs
@@ -208,6 +208,66 @@ defmodule I18NAPI.StatisticsTest do
       assert locale.count_of_keys_need_check == 2
     end
 
+    @default_translation_key_attrs %{
+      context: "default",
+      is_removed: false,
+      key: "default",
+      default_value: "default"
+    }
+
+    @verified_translation_key_attrs %{
+      context: "verified",
+      is_removed: false,
+      key: "verified",
+      default_value: "verified"
+    }
+
+    @verified_translation_attrs %{
+      value: "verified",
+      status: :verified
+    }
+
+    @need_check_translation_attrs %{
+      value: "need_check",
+      status: :need_check
+    }
+
+    test "update_count_choice/3 integration" do
+      project = project_fixture(%{}, user_fixture())
+      locale = Translations.get_default_locale!(project.id)
+      assert project.total_count_of_translation_keys == 0
+      assert locale.count_of_not_verified_keys == 0
+      assert locale.count_of_verified_keys == 0
+      assert locale.count_of_translated_keys == 0
+      assert locale.count_of_untranslated_keys == 0
+      assert locale.count_of_keys_need_check == 0
+
+      {:ok, translation_key} = @default_translation_key_attrs |> Translations.create_translation_key(project.id)
+
+      project = Projects.get_project!(project.id)
+      locale = Translations.get_locale!(locale.id)
+
+      assert project.total_count_of_translation_keys == 1
+      assert locale.count_of_not_verified_keys == 1
+      assert locale.count_of_verified_keys == 0
+      assert locale.count_of_translated_keys == 1
+      assert locale.count_of_untranslated_keys == 0
+      assert locale.count_of_keys_need_check == 0
+
+      {:ok, translation_key} = @verified_translation_key_attrs |> Translations.create_translation_key(project.id)
+#      Translations.get_default_translation(translation_key.id)
+#      |> Translations.update_translation(@verified_translation_attrs)
+
+      locale = Translations.get_locale!(locale.id)
+
+      assert project.total_count_of_translation_keys == 2
+      assert locale.count_of_not_verified_keys == 1
+      assert locale.count_of_verified_keys == 1
+      assert locale.count_of_translated_keys == 2
+      assert locale.count_of_untranslated_keys == 0
+      assert locale.count_of_keys_need_check == 0
+    end
+
   end
 
 end

--- a/test/api/translations/statistics_test.exs
+++ b/test/api/translations/statistics_test.exs
@@ -8,7 +8,6 @@ defmodule I18NAPI.StatisticsTest do
   alias I18NAPI.Accounts
   alias I18NAPI.Accounts.User
   alias I18NAPI.Projects
-  alias I18NAPI.Projects.Project
 
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(I18NAPI.Repo)
@@ -109,16 +108,6 @@ defmodule I18NAPI.StatisticsTest do
       translation_key
     end
 
-    @valid_translation_attrs %{
-      value: "some translation value",
-      status: :verified
-    }
-    @alter_translation_attrs %{
-      value: "some alter value",
-      status: :unverified
-    }
-    @invalid_translation_attrs %{value: nil, status: nil}
-
     def translation_fixture(attrs, locale_id, translation_key_id) do
 
       attrs = %{translation_key_id: translation_key_id}
@@ -132,8 +121,8 @@ defmodule I18NAPI.StatisticsTest do
     test "calculate count of verified and unverified keys at locale" do
       project = project_fixture(%{}, user_fixture())
       locale = Translations.get_default_locale!(project.id)
-      translation_key = translation_key_fixture(@valid_translation_key_attrs, project.id)
-      alter_translation_key = translation_key_fixture(@alter_translation_key_attrs, project.id)
+      translation_key_fixture(@valid_translation_key_attrs, project.id)
+      translation_key_fixture(@alter_translation_key_attrs, project.id)
 
       co_verified_k = Statistics.calculate_count_of_keys_at_locale_by_status(locale.id, :verified)
       co_unverified_k = Statistics.calculate_count_of_keys_at_locale_by_status(locale.id, :unverified)
@@ -145,8 +134,8 @@ defmodule I18NAPI.StatisticsTest do
     test "update counts at locale" do
       project = project_fixture(%{}, user_fixture())
       locale = Translations.get_default_locale!(project.id)
-      translation_key = translation_key_fixture(@valid_translation_key_attrs, project.id)
-      alter_translation_key = translation_key_fixture(@alter_translation_key_attrs, project.id)
+      translation_key_fixture(@valid_translation_key_attrs, project.id)
+      translation_key_fixture(@alter_translation_key_attrs, project.id)
 
       assert locale.total_count_of_translation_keys == 0
       assert locale.count_of_not_verified_keys == 0

--- a/test/api/translations/translations_test.exs
+++ b/test/api/translations/translations_test.exs
@@ -311,6 +311,17 @@ defmodule I18NAPI.TranslationsTest do
       assert translation == Translations.get_translation!(translation.id)
     end
 
+    test "update_translation/2 with valid with unused parameter data updates the translation" do
+      project_id = project_fixture(@valid_project_attrs, user_fixture()).id
+      translation = translation_fixture(@valid_translation_attrs, project_id)
+      attrs = @update_translation_attrs |> Enum.into(%{locale_id: (translation.locale_id)-1})
+
+      assert {:ok, translation} = Translations.update_translation(translation, attrs)
+      assert %Translation{} = translation
+      assert translation.is_removed == false
+      assert translation.value == @update_translation_attrs.value
+    end
+
     test "delete_translation/1 deletes the translation" do
       user = user_fixture()
       project_id = project_fixture(@valid_project_attrs, user).id

--- a/test/api/translations/translations_test.exs
+++ b/test/api/translations/translations_test.exs
@@ -5,7 +5,6 @@ defmodule I18NAPI.TranslationsTest do
   use I18NAPI.DataCase
   alias I18NAPI.Translations
   alias I18NAPI.Projects
-  alias I18NAPI.Projects.Project
   alias I18NAPI.Accounts
   alias I18NAPI.Accounts.User
 
@@ -68,7 +67,7 @@ defmodule I18NAPI.TranslationsTest do
 
     def locale_fixture(attrs \\ %{}, project_id \\ nil) do
       project_id = unless is_integer(project_id) do
-        project_id = project_fixture(@valid_project_attrs, user_fixture()).id
+        project_fixture(@valid_project_attrs, user_fixture()).id
       else
         project_id
       end
@@ -155,7 +154,7 @@ defmodule I18NAPI.TranslationsTest do
 
     def translation_key_fixture(attrs \\ %{}, project_id \\ nil) do
       project_id = unless is_integer(project_id) do
-        project_id = project_fixture(@valid_project_attrs, user_fixture()).id
+        project_fixture(@valid_project_attrs, user_fixture()).id
       else
         project_id
       end
@@ -245,7 +244,7 @@ defmodule I18NAPI.TranslationsTest do
 
     def translation_fixture(attrs, project_id) do
       project_id = unless is_integer(project_id) do
-        project_id = project_fixture(@valid_project_attrs, user_fixture()).id
+        project_fixture(@valid_project_attrs, user_fixture()).id
       else
         project_id
       end

--- a/test/api/translations/translations_test.exs
+++ b/test/api/translations/translations_test.exs
@@ -1,5 +1,5 @@
 defmodule I18NAPI.TranslationsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   @moduletag :translation_api
 
   use I18NAPI.DataCase
@@ -8,6 +8,12 @@ defmodule I18NAPI.TranslationsTest do
   alias I18NAPI.Projects.Project
   alias I18NAPI.Accounts
   alias I18NAPI.Accounts.User
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(I18NAPI.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(I18NAPI.Repo, {:shared, self()})
+    :ok
+  end
 
   @user_attrs %{
     name: "test name",

--- a/test/api/translations/translations_test.exs
+++ b/test/api/translations/translations_test.exs
@@ -61,9 +61,10 @@ defmodule I18NAPI.TranslationsTest do
     }
 
     def locale_fixture(attrs \\ %{}, project_id \\ nil) do
-      unless is_integer(project_id) do
-        user = user_fixture()
-        project_id = project_fixture(@valid_project_attrs, user).id
+      project_id = unless is_integer(project_id) do
+        project_id = project_fixture(@valid_project_attrs, user_fixture()).id
+      else
+        project_id
       end
 
       {:ok, locale} =
@@ -147,10 +148,12 @@ defmodule I18NAPI.TranslationsTest do
     }
 
     def translation_key_fixture(attrs \\ %{}, project_id \\ nil) do
-      unless is_integer(project_id) do
-        user = user_fixture()
-        project_id = project_fixture(@valid_project_attrs, user).id
+      project_id = unless is_integer(project_id) do
+        project_id = project_fixture(@valid_project_attrs, user_fixture()).id
+      else
+        project_id
       end
+
       attrs = Enum.into(attrs, @valid_translation_key_attrs)
 
       {:ok, translation_key} =
@@ -235,8 +238,10 @@ defmodule I18NAPI.TranslationsTest do
     @invalid_translation_attrs %{value: nil, status: nil}
 
     def translation_fixture(attrs, project_id) do
-      unless is_integer(project_id) do
+      project_id = unless is_integer(project_id) do
         project_id = project_fixture(@valid_project_attrs, user_fixture()).id
+      else
+        project_id
       end
 
       translation_key_id = translation_key_fixture(%{

--- a/test/api/utilites/mailer_test.exs
+++ b/test/api/utilites/mailer_test.exs
@@ -1,0 +1,34 @@
+defmodule I18NAPI.MailerTest do
+  use ExUnit.Case, async: true
+  use I18NAPI.DataCase
+
+  @moduletag :mailer_api
+
+  import Swoosh.TestAssertions
+  import Swoosh.TestAssertions
+
+  alias I18NAPI.UserEmail
+  alias I18NAPI.Utilites
+  alias I18NAPI.Accounts.User
+
+  @user_attrs %{
+    name: "test name",
+    email: "test@email.test",
+    password: "Qw!23456",
+    password_confirmation: "Qw!23456",
+    source: "test source",
+  }
+
+  def user_fixture(attrs \\ %{}) do
+    {:ok, user} = %User{}
+                  |> User.changeset(attrs |> Enum.into(@user_attrs))
+                  |> Repo.insert()
+
+    user |> Map.put(:confirmation_token, Utilites.random_string(25))
+  end
+
+  test "deliver confirmation email" do
+    UserEmail.create_confirmation_email(user_fixture()) |> I18NAPI.Mailer.deliver
+    assert_email_sent()
+  end
+end

--- a/test/api_web/controllers/confirmation_controller_test.exs
+++ b/test/api_web/controllers/confirmation_controller_test.exs
@@ -1,0 +1,59 @@
+defmodule I18NAPIWeb.ConfirmationControllerTest do
+  use ExUnit.Case, async: true
+  @moduletag :confirmation_controller
+
+  use I18NAPIWeb.ConnCase
+
+  alias I18NAPI.Repo
+  alias I18NAPI.Accounts
+  alias I18NAPI.Accounts.User
+
+  @fixture_user_attrs %{
+    name: "fixture name",
+    email: "fixture@email.test",
+    password: "Qw!23456",
+    password_confirmation: "Qw!23456",
+    source: "fixture source"
+  }
+
+  def fixture(:user) do
+    {:ok, user} =     %User{}
+                      |> User.changeset(@fixture_user_attrs)
+                      |> Repo.insert()
+    I18NAPI.Accounts.Confirmation.send_confirmation_email({:ok, user})
+    Accounts.get_user!(user.id)
+  end
+
+
+  describe "confirmate user email" do
+    test "if token is valid", %{conn: conn} do
+      user = fixture(:user)
+      conn = post(conn, confirmation_path(conn, :confirm, token: user.confirmation_token))
+      assert json_response(conn, 200)
+
+      assert %User{} = user = Accounts.get_user!(user.id)
+      assert user.is_confirmed
+      refute user.confirmation_token
+    end
+
+    test "if token is invalid", %{conn: conn} do
+      user = fixture(:user)
+      conn = post(conn, confirmation_path(conn, :confirm, token: "abracadabra"))
+      assert json_response(conn, 404)
+
+      assert %User{} = user = Accounts.get_user!(user.id)
+      refute user.is_confirmed
+      assert user.confirmation_token
+    end
+
+    test "if token is nil", %{conn: conn} do
+      user = fixture(:user)
+      conn = post(conn, confirmation_path(conn, :confirm, token: nil))
+      assert json_response(conn, 404)
+
+      assert %User{} = user = Accounts.get_user!(user.id)
+      refute user.is_confirmed
+      assert user.confirmation_token
+    end
+  end
+end

--- a/test/api_web/controllers/confirmation_controller_test.exs
+++ b/test/api_web/controllers/confirmation_controller_test.exs
@@ -4,9 +4,11 @@ defmodule I18NAPIWeb.ConfirmationControllerTest do
 
   use I18NAPIWeb.ConnCase
 
-  alias I18NAPI.Repo
   alias I18NAPI.Accounts
+  alias I18NAPI.Accounts.Confirmation
   alias I18NAPI.Accounts.User
+  alias I18NAPI.Repo
+  alias I18NAPI.Utilites
 
   @fixture_user_attrs %{
     name: "fixture name",
@@ -17,13 +19,14 @@ defmodule I18NAPIWeb.ConfirmationControllerTest do
   }
 
   def fixture(:user) do
-    {:ok, user} =     %User{}
-                      |> User.changeset(@fixture_user_attrs)
-                      |> Repo.insert()
-    I18NAPI.Accounts.Confirmation.send_confirmation_email({:ok, user})
+    {:ok, user} =
+      %User{}
+      |> User.changeset(Map.put(@fixture_user_attrs, :confirmation_token, Utilites.random_string(32)))
+      |> Repo.insert()
+
+    Confirmation.send_confirmation_email(user)
     Accounts.get_user!(user.id)
   end
-
 
   describe "confirmate user email" do
     test "if token is valid", %{conn: conn} do

--- a/test/api_web/controllers/locale_controller_test.exs
+++ b/test/api_web/controllers/locale_controller_test.exs
@@ -43,17 +43,19 @@ defmodule I18NAPIWeb.LocaleControllerTest do
 
   describe "index" do
     test "lists all locales", %{conn: conn} do
-      conn = get(conn, locale_path(conn, :index))
+      locale = fixture( :locale)
+      conn = get(conn, project_locale_path(conn, :index, locale.project_id, locale))
       assert json_response(conn, 200)["data"] == []
     end
   end
 
   describe "create locale" do
     test "renders locale when data is valid", %{conn: conn} do
-      conn = post(conn, locale_path(conn, :create), locale: @create_attrs)
+      locale = fixture( :locale)
+      conn = post(conn, project_locale_path(conn, locale.project_id, :create), locale: @create_attrs)
       assert %{"id" => id} = json_response(conn, 201)["data"]
 
-      conn = get(conn, locale_path(conn, :show, id))
+      conn = get(conn, project_locale_path(conn, locale.project_id, :show, id))
 
       assert json_response(conn, 200)["data"] == %{
                "id" => id,
@@ -68,7 +70,8 @@ defmodule I18NAPIWeb.LocaleControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      conn = post(conn, locale_path(conn, :create), locale: @invalid_attrs)
+      locale = fixture( :locale)
+      conn = post(conn, project_locale_path(conn, locale.project_id, :create), locale: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -77,10 +80,10 @@ defmodule I18NAPIWeb.LocaleControllerTest do
     setup [:create_locale]
 
     test "renders locale when data is valid", %{conn: conn, locale: %Locale{id: id} = locale} do
-      conn = put(conn, locale_path(conn, :update, locale), locale: @update_attrs)
+      conn = put(conn, project_locale_path(conn, locale.project_id, :update, locale), locale: @update_attrs)
       assert %{"id" => ^id} = json_response(conn, 200)["data"]
 
-      conn = get(conn, locale_path(conn, :show, id))
+      conn = get(conn, project_locale_path(conn, locale.project_id, :show, id))
 
       assert json_response(conn, 200)["data"] == %{
                "id" => id,
@@ -95,7 +98,7 @@ defmodule I18NAPIWeb.LocaleControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn, locale: locale} do
-      conn = put(conn, locale_path(conn, :update, locale), locale: @invalid_attrs)
+      conn = put(conn, project_locale_path(conn, locale.project_id, :update, locale), locale: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -104,11 +107,11 @@ defmodule I18NAPIWeb.LocaleControllerTest do
     setup [:create_locale]
 
     test "deletes chosen locale", %{conn: conn, locale: locale} do
-      conn = delete(conn, locale_path(conn, :delete, locale))
+      conn = delete(conn, project_locale_path(conn, locale.project_id, :delete, locale))
       assert response(conn, 204)
 
       assert_error_sent(404, fn ->
-        get(conn, locale_path(conn, :show, locale))
+        get(conn, project_locale_path(conn, locale.project_id, :show, locale))
       end)
     end
   end

--- a/test/api_web/controllers/locale_controller_test.exs
+++ b/test/api_web/controllers/locale_controller_test.exs
@@ -23,38 +23,30 @@ defmodule I18NAPIWeb.LocaleControllerTest do
 
   def user_fixture(attrs \\ %{}) do
     {result, user} = Accounts.find_and_confirm_user(@user_attrs.email, @user_attrs.password)
-
-    if :error == result do
-      {:ok, user} =
-        attrs
-        |> Enum.into(@user_attrs)
-        |> Accounts.create_user()
-    end
-
     user
+    user = with :error <- result,
+                do: with {:ok, user} <- attrs |> Enum.into(@user_attrs) |> Accounts.create_user(),
+                    do: user
   end
 
   @valid_project_attrs %{
     name: "some name",
     default_locale: "en"
   }
-
-  def project_fixture(attrs \\ %{}, %User{} = user) do
-    {:ok, project} =
-      attrs
-      |> Enum.into(@valid_project_attrs)
-      |> Projects.create_project(user)
-
+  
+  def project_fixture(conn) do
+    {:ok, project} = @valid_project_attrs |> Projects.create_project(conn.user)
     project
   end
 
   setup %{conn: conn} do
     user = user_fixture()
-      {:ok, jwt, _claims} = I18NAPI.Guardian.encode_and_sign(user)
+    {:ok, jwt, _claims} = I18NAPI.Guardian.encode_and_sign(user)
     conn =
       conn
       |> put_req_header("accept", "application/json")
       |> put_req_header("authorization", "Bearer #{jwt}")
+      |> Map.put(:user, user)
 
     {:ok, conn: conn}
   end
@@ -98,39 +90,28 @@ defmodule I18NAPIWeb.LocaleControllerTest do
     removed_at: nil
   }
 
-  def fixture(:locale) do
-    user = user_fixture()
-    project_id = project_fixture(@valid_project_attrs, user).id
-    query = from(
-      p in Locale,
-      select: p,
-      where: p.project_id == ^project_id and p.locale == ^@create_attrs.locale
-    )
-    result = Repo.one(query)
+  def locale_fixture(project) do
+    default_locale = Translations.get_default_locale!(project.id)
 
-    if nil == result do
-      result = Translations.create_locale(@create_attrs, project_id)
+    if nil == default_locale do
+      {:ok, new_locale} = Translations.create_locale(@create_attrs, project.id)
+      new_locale
+    else
+      default_locale
     end
-
-    {:ok, locale} = result
-    locale
-  end
-
-  setup %{conn: conn} do
-    {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 
   describe "index" do
     test "lists all locales", %{conn: conn} do
-      locale = fixture( :locale)
-      conn = get(conn, project_locale_path(conn, :index, locale.project_id, locale))
+      project = project_fixture(conn)
+      conn = get(conn, project_locale_path(conn, :index, project.id))
       assert json_response(conn, 200)["data"] == []
     end
   end
 
   describe "create locale" do
     test "renders locale when data is valid", %{conn: conn} do
-      project_id = fixture(:locale).project_id
+      project_id = project_fixture(conn).id
       conn = post(conn, project_locale_path(conn, :create, project_id), locale: @valid_attrs)
       assert %{"id" => id} = json_response(conn, 201)["data"]
       query = from(
@@ -140,35 +121,24 @@ defmodule I18NAPIWeb.LocaleControllerTest do
       )
       result_locale = Repo.one(query)
       assert result_locale.locale == @valid_attrs.locale
-
-#      conn = get(conn, project_locale_path(conn, :show, locale.project_id, id))
-
-#      assert json_response(conn, 200)["data"] == %{
-#               "id" => id,
-#               "count_of_keys" => 42,
-#               "count_of_translated_keys" => 42,
-#               "count_of_words" => 42,
-#               "is_default" => true,
-#               "is_removed" => true,
-#               "locale" => "another locale",
-#               "removed_at" => ~N[2010-04-17 14:00:00.000000]
-#             }
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      locale = fixture( :locale)
+      project = project_fixture(conn)
+      locale = locale_fixture(project)
       conn = post(conn, project_locale_path(conn, :create, locale.project_id), locale: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
 
   describe "update locale" do
-    setup [:create_locale]
-
-    test "renders locale when data is valid", %{conn: conn, locale: %Locale{id: id} = locale} do
-      project_id = locale.project_id
+    test "renders locale when data is valid", %{conn: conn} do
+      project = project_fixture(conn)
+      locale = locale_fixture(project)
+      project_id = project.id
       conn = put(conn, project_locale_path(conn, :update, project_id, locale), locale: @update_attrs)
-      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+      assert 1 = 2
+      #assert %{"id" => ^id} = json_response(conn, 200)["data"]
 
       query = from(
         p in Locale,
@@ -177,19 +147,6 @@ defmodule I18NAPIWeb.LocaleControllerTest do
       )
       result_locale = Repo.one(query)
       assert result_locale.locale == @update_attrs.locale
-
-#      conn = get(conn, project_locale_path(conn, :show, locale.project_id, id))
-
-#      assert json_response(conn, 200)["data"] == %{
-#               "id" => id,
-#               "count_of_keys" => 43,
-#               "count_of_translated_keys" => 43,
-#               "count_of_words" => 43,
-#               "is_default" => false,
-#               "is_removed" => false,
-#               "locale" => "some updated locale",
-#               "removed_at" => ~N[2011-05-18 15:01:01.000000]
-#             }
     end
 
     test "renders errors when data is invalid", %{conn: conn, locale: locale} do
@@ -199,7 +156,10 @@ defmodule I18NAPIWeb.LocaleControllerTest do
   end
 
   describe "delete locale" do
-    setup [:create_locale]
+    test "deletes chosen locale", %{conn: conn} do
+      project = project_fixture(conn)
+      locale = locale_fixture(project)
+      no_content_response = delete(conn, project_locale_path(conn, :delete, locale.project_id, locale))
 
     test "deletes chosen locale", %{conn: conn, locale: locale} do
       result = delete(conn, project_locale_path(conn, :delete, locale.project_id, locale))
@@ -218,10 +178,5 @@ defmodule I18NAPIWeb.LocaleControllerTest do
         get(conn, project_locale_path(conn, :show, locale.project_id, locale))
       end)
     end
-  end
-
-  defp create_locale(_) do
-    locale = fixture(:locale)
-    {:ok, locale: locale}
   end
 end

--- a/test/api_web/controllers/locale_controller_test.exs
+++ b/test/api_web/controllers/locale_controller_test.exs
@@ -161,22 +161,11 @@ defmodule I18NAPIWeb.LocaleControllerTest do
       locale = locale_fixture(project)
       no_content_response = delete(conn, project_locale_path(conn, :delete, locale.project_id, locale))
 
-    test "deletes chosen locale", %{conn: conn, locale: locale} do
-      result = delete(conn, project_locale_path(conn, :delete, locale.project_id, locale))
-      assert response(result, 200)
+      assert response(no_content_response, 204)
 
-      project_id = locale.project_id
-      query = from(
-        p in Locale,
-        select: p,
-        where: p.project_id == ^project_id and p.locale == ^@create_attrs.locale
-      )
-      result_locale = Repo.one(query)
-      assert result_locale.locale == @create_attrs.locale
+      no_content_response = delete(conn, project_locale_path(conn, :show, locale.project_id, locale))
 
-      assert_error_sent(404, fn ->
-        get(conn, project_locale_path(conn, :show, locale.project_id, locale))
-      end)
+      assert response(no_content_response, 204)
     end
   end
 end

--- a/test/api_web/controllers/locale_controller_test.exs
+++ b/test/api_web/controllers/locale_controller_test.exs
@@ -7,11 +7,8 @@ defmodule I18NAPIWeb.LocaleControllerTest do
   alias I18NAPI.Translations
   alias I18NAPI.Translations.Locale
   alias I18NAPI.Projects
-  alias I18NAPI.Projects.Project
   alias I18NAPI.Accounts
-  alias I18NAPI.Accounts.User
   import Ecto.Query, warn: false
-  alias I18NAPI.Repo
 
   @user_attrs %{
     name: "test name",
@@ -23,10 +20,12 @@ defmodule I18NAPIWeb.LocaleControllerTest do
 
   def user_fixture(attrs \\ %{}) do
     {result, user} = Accounts.find_and_confirm_user(@user_attrs.email, @user_attrs.password)
-    user
-    user = with :error <- result,
-                do: with {:ok, user} <- attrs |> Enum.into(@user_attrs) |> Accounts.create_user(),
-                    do: user
+    if (:error == result) do
+      with {:ok, new_user} <- attrs |> Enum.into(@user_attrs) |> Accounts.create_user(),
+           do: new_user
+    else
+      user
+    end
   end
 
   @valid_project_attrs %{

--- a/test/api_web/controllers/locale_controller_test.exs
+++ b/test/api_web/controllers/locale_controller_test.exs
@@ -1,8 +1,63 @@
 defmodule I18NAPIWeb.LocaleControllerTest do
+  use ExUnit.Case, async: true
+  @moduletag :locale_controller
+
   use I18NAPIWeb.ConnCase
 
   alias I18NAPI.Translations
   alias I18NAPI.Translations.Locale
+  alias I18NAPI.Projects
+  alias I18NAPI.Projects.Project
+  alias I18NAPI.Accounts
+  alias I18NAPI.Accounts.User
+  import Ecto.Query, warn: false
+  alias I18NAPI.Repo
+
+  @user_attrs %{
+    name: "test name",
+    email: "test@email.test",
+    password: "Qw!23456",
+    password_confirmation: "Qw!23456",
+    source: "test source"
+  }
+
+  def user_fixture(attrs \\ %{}) do
+    {result, user} = Accounts.find_and_confirm_user(@user_attrs.email, @user_attrs.password)
+
+    if :error == result do
+      {:ok, user} =
+        attrs
+        |> Enum.into(@user_attrs)
+        |> Accounts.create_user()
+    end
+
+    user
+  end
+
+  @valid_project_attrs %{
+    name: "some name",
+    default_locale: "en"
+  }
+
+  def project_fixture(attrs \\ %{}, %User{} = user) do
+    {:ok, project} =
+      attrs
+      |> Enum.into(@valid_project_attrs)
+      |> Projects.create_project(user)
+
+    project
+  end
+
+  setup %{conn: conn} do
+    user = user_fixture()
+      {:ok, jwt, _claims} = I18NAPI.Guardian.encode_and_sign(user)
+    conn =
+      conn
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("authorization", "Bearer #{jwt}")
+
+    {:ok, conn: conn}
+  end
 
   @create_attrs %{
     count_of_keys: 42,
@@ -13,6 +68,17 @@ defmodule I18NAPIWeb.LocaleControllerTest do
     locale: "some locale",
     removed_at: ~N[2010-04-17 14:00:00.000000]
   }
+
+  @valid_attrs %{
+    count_of_keys: 42,
+    count_of_translated_keys: 42,
+    count_of_words: 42,
+    is_default: true,
+    is_removed: true,
+    locale: "another locale",
+    removed_at: ~N[2010-04-17 14:00:00.000000]
+  }
+
   @update_attrs %{
     count_of_keys: 43,
     count_of_translated_keys: 43,
@@ -33,7 +99,20 @@ defmodule I18NAPIWeb.LocaleControllerTest do
   }
 
   def fixture(:locale) do
-    {:ok, locale} = Translations.create_locale(@create_attrs)
+    user = user_fixture()
+    project_id = project_fixture(@valid_project_attrs, user).id
+    query = from(
+      p in Locale,
+      select: p,
+      where: p.project_id == ^project_id and p.locale == ^@create_attrs.locale
+    )
+    result = Repo.one(query)
+
+    if nil == result do
+      result = Translations.create_locale(@create_attrs, project_id)
+    end
+
+    {:ok, locale} = result
     locale
   end
 
@@ -51,27 +130,34 @@ defmodule I18NAPIWeb.LocaleControllerTest do
 
   describe "create locale" do
     test "renders locale when data is valid", %{conn: conn} do
-      locale = fixture( :locale)
-      conn = post(conn, project_locale_path(conn, locale.project_id, :create), locale: @create_attrs)
+      project_id = fixture(:locale).project_id
+      conn = post(conn, project_locale_path(conn, :create, project_id), locale: @valid_attrs)
       assert %{"id" => id} = json_response(conn, 201)["data"]
+      query = from(
+        p in Locale,
+        select: p,
+        where: p.project_id == ^project_id and p.locale == ^@valid_attrs.locale
+      )
+      result_locale = Repo.one(query)
+      assert result_locale.locale == @valid_attrs.locale
 
-      conn = get(conn, project_locale_path(conn, locale.project_id, :show, id))
+#      conn = get(conn, project_locale_path(conn, :show, locale.project_id, id))
 
-      assert json_response(conn, 200)["data"] == %{
-               "id" => id,
-               "count_of_keys" => 42,
-               "count_of_translated_keys" => 42,
-               "count_of_words" => 42,
-               "is_default" => true,
-               "is_removed" => true,
-               "locale" => "some locale",
-               "removed_at" => ~N[2010-04-17 14:00:00.000000]
-             }
+#      assert json_response(conn, 200)["data"] == %{
+#               "id" => id,
+#               "count_of_keys" => 42,
+#               "count_of_translated_keys" => 42,
+#               "count_of_words" => 42,
+#               "is_default" => true,
+#               "is_removed" => true,
+#               "locale" => "another locale",
+#               "removed_at" => ~N[2010-04-17 14:00:00.000000]
+#             }
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
       locale = fixture( :locale)
-      conn = post(conn, project_locale_path(conn, locale.project_id, :create), locale: @invalid_attrs)
+      conn = post(conn, project_locale_path(conn, :create, locale.project_id), locale: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -80,25 +166,34 @@ defmodule I18NAPIWeb.LocaleControllerTest do
     setup [:create_locale]
 
     test "renders locale when data is valid", %{conn: conn, locale: %Locale{id: id} = locale} do
-      conn = put(conn, project_locale_path(conn, locale.project_id, :update, locale), locale: @update_attrs)
+      project_id = locale.project_id
+      conn = put(conn, project_locale_path(conn, :update, project_id, locale), locale: @update_attrs)
       assert %{"id" => ^id} = json_response(conn, 200)["data"]
 
-      conn = get(conn, project_locale_path(conn, locale.project_id, :show, id))
+      query = from(
+        p in Locale,
+        select: p,
+        where: p.project_id == ^project_id and p.locale == ^@update_attrs.locale
+      )
+      result_locale = Repo.one(query)
+      assert result_locale.locale == @update_attrs.locale
 
-      assert json_response(conn, 200)["data"] == %{
-               "id" => id,
-               "count_of_keys" => 43,
-               "count_of_translated_keys" => 43,
-               "count_of_words" => 43,
-               "is_default" => false,
-               "is_removed" => false,
-               "locale" => "some updated locale",
-               "removed_at" => ~N[2011-05-18 15:01:01.000000]
-             }
+#      conn = get(conn, project_locale_path(conn, :show, locale.project_id, id))
+
+#      assert json_response(conn, 200)["data"] == %{
+#               "id" => id,
+#               "count_of_keys" => 43,
+#               "count_of_translated_keys" => 43,
+#               "count_of_words" => 43,
+#               "is_default" => false,
+#               "is_removed" => false,
+#               "locale" => "some updated locale",
+#               "removed_at" => ~N[2011-05-18 15:01:01.000000]
+#             }
     end
 
     test "renders errors when data is invalid", %{conn: conn, locale: locale} do
-      conn = put(conn, project_locale_path(conn, locale.project_id, :update, locale), locale: @invalid_attrs)
+      conn = put(conn, project_locale_path(conn, :update, locale.project_id, locale), locale: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -107,11 +202,20 @@ defmodule I18NAPIWeb.LocaleControllerTest do
     setup [:create_locale]
 
     test "deletes chosen locale", %{conn: conn, locale: locale} do
-      conn = delete(conn, project_locale_path(conn, locale.project_id, :delete, locale))
-      assert response(conn, 204)
+      result = delete(conn, project_locale_path(conn, :delete, locale.project_id, locale))
+      assert response(result, 200)
+
+      project_id = locale.project_id
+      query = from(
+        p in Locale,
+        select: p,
+        where: p.project_id == ^project_id and p.locale == ^@create_attrs.locale
+      )
+      result_locale = Repo.one(query)
+      assert result_locale.locale == @create_attrs.locale
 
       assert_error_sent(404, fn ->
-        get(conn, project_locale_path(conn, locale.project_id, :show, locale))
+        get(conn, project_locale_path(conn, :show, locale.project_id, locale))
       end)
     end
   end

--- a/test/api_web/controllers/locale_controller_test.exs
+++ b/test/api_web/controllers/locale_controller_test.exs
@@ -52,42 +52,23 @@ defmodule I18NAPIWeb.LocaleControllerTest do
   end
 
   @create_attrs %{
-    count_of_keys: 42,
-    count_of_translated_keys: 42,
-    count_of_words: 42,
     is_default: true,
-    is_removed: true,
     locale: "some locale",
-    removed_at: ~N[2010-04-17 14:00:00.000000]
   }
 
   @valid_attrs %{
-    count_of_keys: 42,
-    count_of_translated_keys: 42,
-    count_of_words: 42,
     is_default: true,
-    is_removed: true,
     locale: "another locale",
-    removed_at: ~N[2010-04-17 14:00:00.000000]
   }
 
   @update_attrs %{
-    count_of_keys: 43,
-    count_of_translated_keys: 43,
-    count_of_words: 43,
     is_default: false,
-    is_removed: false,
     locale: "some updated locale",
-    removed_at: ~N[2011-05-18 15:01:01.000000]
   }
   @invalid_attrs %{
-    count_of_keys: nil,
-    count_of_translated_keys: nil,
-    count_of_words: nil,
     is_default: nil,
     is_removed: nil,
     locale: nil,
-    removed_at: nil
   }
 
   def locale_fixture(project) do
@@ -114,13 +95,11 @@ defmodule I18NAPIWeb.LocaleControllerTest do
       project_id = project_fixture(conn).id
       conn = post(conn, project_locale_path(conn, :create, project_id), locale: @valid_attrs)
       assert %{"id" => id} = json_response(conn, 201)["data"]
-      query = from(
-        p in Locale,
-        select: p,
-        where: p.project_id == ^project_id and p.locale == ^@valid_attrs.locale
-      )
-      result_locale = Repo.one(query)
+
+      result_locale = Translations.get_locale!(id)
+      assert %Locale{} = result_locale
       assert result_locale.locale == @valid_attrs.locale
+      assert result_locale.is_default == @valid_attrs.is_default
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
@@ -137,19 +116,15 @@ defmodule I18NAPIWeb.LocaleControllerTest do
       locale = locale_fixture(project)
       project_id = project.id
       conn = put(conn, project_locale_path(conn, :update, project_id, locale), locale: @update_attrs)
-      assert 1 = 2
-      #assert %{"id" => ^id} = json_response(conn, 200)["data"]
+      assert %{"id" => id} = json_response(conn, 200)["data"]
 
-      query = from(
-        p in Locale,
-        select: p,
-        where: p.project_id == ^project_id and p.locale == ^@update_attrs.locale
-      )
-      result_locale = Repo.one(query)
+      result_locale = Translations.get_locale!(locale.id)
       assert result_locale.locale == @update_attrs.locale
     end
 
-    test "renders errors when data is invalid", %{conn: conn, locale: locale} do
+    test "renders errors when data is invalid", %{conn: conn} do
+      project = project_fixture(conn)
+      locale = locale_fixture(project)
       conn = put(conn, project_locale_path(conn, :update, locale.project_id, locale), locale: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end

--- a/test/api_web/controllers/project_controller_test.exs
+++ b/test/api_web/controllers/project_controller_test.exs
@@ -18,10 +18,12 @@ defmodule I18NAPIWeb.ProjectControllerTest do
 
   def user_fixture(attrs \\ %{}) do
     {result, user} = Accounts.find_and_confirm_user(@user_attrs.email, @user_attrs.password)
-    user
-    user = with :error <- result,
-                do: with {:ok, user} <- attrs |> Enum.into(@user_attrs) |> Accounts.create_user(),
-                    do: user
+    if (:error == result) do
+      with {:ok, new_user} <- attrs |> Enum.into(@user_attrs) |> Accounts.create_user(),
+           do: new_user
+    else
+      user
+    end
   end
 
   @create_attrs %{

--- a/test/api_web/controllers/project_controller_test.exs
+++ b/test/api_web/controllers/project_controller_test.exs
@@ -1,44 +1,27 @@
 defmodule I18NAPIWeb.ProjectControllerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   @moduletag :project_controller
 
   use I18NAPIWeb.ConnCase
 
   alias I18NAPI.Accounts
-  alias I18NAPI.Accounts.User
   alias I18NAPI.Projects
   alias I18NAPI.Projects.Project
 
   @user_attrs %{
-    name: "test name",
-    email: "test@email.test",
+    name: "project_controller test name",
+    email: "project_controller@email.test",
     password: "Qw!23456",
     password_confirmation: "Qw!23456",
-    source: "test source"
+    source: "project_controller test source"
   }
 
   def user_fixture(attrs \\ %{}) do
     {result, user} = Accounts.find_and_confirm_user(@user_attrs.email, @user_attrs.password)
-
-    if :error == result do
-      {:ok, user} =
-        attrs
-        |> Enum.into(@user_attrs)
-        |> Accounts.create_user()
-    end
-
     user
-  end
-
-  setup %{conn: conn} do
-    user = user_fixture()
-    {:ok, jwt, _claims} = I18NAPI.Guardian.encode_and_sign(user)
-    conn =
-      conn
-      |> put_req_header("accept", "application/json")
-      |> put_req_header("authorization", "Bearer #{jwt}")
-
-    {:ok, conn: conn}
+    user = with :error <- result,
+         do: with {:ok, user} <- attrs |> Enum.into(@user_attrs) |> Accounts.create_user(),
+             do: user
   end
 
   @create_attrs %{
@@ -51,14 +34,21 @@ defmodule I18NAPIWeb.ProjectControllerTest do
   }
   @invalid_attrs %{is_removed: nil, name: nil, removed_at: nil}
 
-  def fixture(:project) do
+  setup %{conn: conn} do
     user = user_fixture()
-    {:ok, project} = @create_attrs |> Projects.create_project(user)
-    project
+    {:ok, jwt, _claims} = I18NAPI.Guardian.encode_and_sign(user)
+    conn =
+      conn
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("authorization", "Bearer #{jwt}")
+      |> Map.put(:user, user)
+
+    {:ok, conn: conn}
   end
 
-  setup %{conn: conn} do
-    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  def create_project(conn) do
+    {:ok, project} = @create_attrs |> Projects.create_project(conn.user)
+    project
   end
 
   describe "index" do
@@ -73,15 +63,11 @@ defmodule I18NAPIWeb.ProjectControllerTest do
       conn = post(conn, project_path(conn, :create), project: @create_attrs)
       assert %{"id" => id} = json_response(conn, 201)["data"]
 
-      assert Projects.get_project!(id) == @create_attrs
-#      conn = get(conn, project_path(conn, :show, id))
+      project = Projects.get_project!(id)
+      assert %Project{} = project
+      assert project.name == @create_attrs.name
+      assert project.default_locale == @create_attrs.default_locale
 
-#      assert json_response(conn, 200)["data"] == %{
-#               "id" => id,
-#               "is_removed" => true,
-#               "name" => "some name",
-#               "removed_at" => ~N[2010-04-17 14:00:00.000000]
-#             }
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
@@ -91,34 +77,33 @@ defmodule I18NAPIWeb.ProjectControllerTest do
   end
 
   describe "update project" do
-    setup [:create_project]
-
-    test "renders project when data is valid", %{conn: conn, project: %Project{id: id} = project} do
+    test "renders project when data is valid", %{conn: conn} do
+      project = create_project(conn)
+      IO.puts "======================"
+      IO.inspect project
+      IO.puts "++++++++++++++++++++++"
       conn = put(conn, project_path(conn, :update, project), project: @update_attrs)
-      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+      assert %{"id" => id} = json_response(conn, 200)["data"]
 
-      assert Projects.get_project!(project.id) == @update_attrs
-
-#      conn = get(conn, project_path(conn, :show, id))
-
-#      assert json_response(conn, 200)["data"] == %{
-#               "id" => id,
-#               "is_removed" => false,
-#               "name" => "some updated name",
-#               "removed_at" => ~N[2011-05-18 15:01:01.000000]
-#             }
+      project = Projects.get_project!(project.id)
+      assert %Project{} = project
+      IO.puts "++++++++++++++++++++++"
+      IO.inspect project
+      IO.puts "++++++++++++++++++++++"
+      assert project.name == @update_attrs.name
+      assert project.default_locale == @update_attrs.default_locale
     end
 
-    test "renders errors when data is invalid", %{conn: conn, project: project} do
+    test "renders errors when data is invalid", %{conn: conn} do
+      project = create_project(conn)
       conn = put(conn, project_path(conn, :update, project), project: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
 
   describe "delete project" do
-    setup [:create_project]
-
-    test "deletes chosen project", %{conn: conn, project: project} do
+   test "deletes chosen project", %{conn: conn} do
+      project = create_project(conn)
       conn = delete(conn, project_path(conn, :delete, project))
       assert response(conn, 204)
 
@@ -128,8 +113,4 @@ defmodule I18NAPIWeb.ProjectControllerTest do
     end
   end
 
-  defp create_project(_) do
-    project = fixture(:project)
-    {:ok, project: project}
-  end
 end

--- a/test/api_web/controllers/project_controller_test.exs
+++ b/test/api_web/controllers/project_controller_test.exs
@@ -46,7 +46,7 @@ defmodule I18NAPIWeb.ProjectControllerTest do
     {:ok, conn: conn}
   end
 
-  def create_project(conn) do
+  def project_fixture(conn) do
     {:ok, project} = @create_attrs |> Projects.create_project(conn.user)
     project
   end
@@ -60,7 +60,7 @@ defmodule I18NAPIWeb.ProjectControllerTest do
 
   describe "show project" do
     test "render project when data is valid", %{conn: conn} do
-      project = create_project(conn)
+      project = project_fixture(conn)
       conn = get(conn, project_path(conn, :show, project.id))
       assert %{"id" => id} = json_response(conn, 200)["data"]
 
@@ -91,7 +91,7 @@ defmodule I18NAPIWeb.ProjectControllerTest do
 
   describe "update project" do
     test "renders project when data is valid", %{conn: conn} do
-      project = create_project(conn)
+      project = project_fixture(conn)
       conn = put(conn, project_path(conn, :update, project), project: @update_attrs)
       assert %{"id" => id} = json_response(conn, 200)["data"]
 
@@ -102,7 +102,7 @@ defmodule I18NAPIWeb.ProjectControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      project = create_project(conn)
+      project = project_fixture(conn)
       conn = put(conn, project_path(conn, :update, project), project: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
@@ -110,7 +110,7 @@ defmodule I18NAPIWeb.ProjectControllerTest do
 
   describe "delete project" do
     test "deletes chosen project", %{conn: conn} do
-      project = create_project(conn)
+      project = project_fixture(conn)
       no_content_response = delete(conn, project_path(conn, :delete, project))
       assert response(no_content_response, 204)
 

--- a/test/api_web/controllers/translation_controller_test.exs
+++ b/test/api_web/controllers/translation_controller_test.exs
@@ -1,8 +1,11 @@
 defmodule I18NAPIWeb.TranslationControllerTest do
+  use ExUnit.Case, async: true
+  @moduletag :translation_controller
+
   use I18NAPIWeb.ConnCase
 
   alias I18NAPI.Translations
-  alias I18NAPI.Translations.Translation
+  alias I18NAPI.Translations.{Translation, Translations}
 
   @create_attrs %{
     is_removed: true,
@@ -16,14 +19,25 @@ defmodule I18NAPIWeb.TranslationControllerTest do
   }
   @invalid_attrs %{is_removed: nil, removed_at: nil, value: nil}
 
-  def fixture(:translation) do
-    {:ok, translation} = Translations.create_translation(@create_attrs)
-    translation
+  def fixture(param) do
+    case param do
+      :translation ->
+        {:ok, translation} = Translations.create_translation(@create_attrs)
+        translation
+
+      :project ->
+        {:ok, project} = Projects.create_project(@create_attrs)
+        project
+    end
   end
 
-  def fixture(:project) do
-    {:ok, project} = Projects.create_project(@create_attrs)
-    project
+  def translation_fixture(attrs, locale_id, translation_key_id) do
+    attrs = %{translation_key_id: translation_key_id}
+            |> Enum.into(attrs)
+
+    {:ok, translation} = Translations.create_translation(attrs, locale_id)
+
+    translation
   end
 
   setup %{conn: conn} do

--- a/test/api_web/controllers/translation_controller_test.exs
+++ b/test/api_web/controllers/translation_controller_test.exs
@@ -21,23 +21,28 @@ defmodule I18NAPIWeb.TranslationControllerTest do
     translation
   end
 
+  def fixture(:project) do
+    {:ok, project} = Projects.create_project(@create_attrs)
+    project
+  end
+
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 
   describe "index" do
     test "lists all translations", %{conn: conn} do
-      conn = get(conn, translation_path(conn, :index))
+      conn = get(conn, project_locale_translation_path(conn, :index, fixture(:project), fixture(:translation).locale_id, fixture(:translation)))
       assert json_response(conn, 200)["data"] == []
     end
   end
 
   describe "create translation" do
     test "renders translation when data is valid", %{conn: conn} do
-      conn = post(conn, translation_path(conn, :create), translation: @create_attrs)
+      conn = post(conn, project_locale_translation_path(conn, :create, fixture(:project), fixture(:translation).locale_id, fixture(:translation)), translation: @create_attrs)
       assert %{"id" => id} = json_response(conn, 201)["data"]
 
-      conn = get(conn, translation_path(conn, :show, id))
+      conn = get(conn, project_locale_translation_path(conn, :show, fixture(:project), fixture(:translation).locale_id, fixture(:translation), id))
 
       assert json_response(conn, 200)["data"] == %{
                "id" => id,
@@ -48,7 +53,7 @@ defmodule I18NAPIWeb.TranslationControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      conn = post(conn, translation_path(conn, :create), translation: @invalid_attrs)
+      conn = post(conn, project_locale_translation_path(conn, :create, fixture(:project), fixture(:translation).locale_id, fixture(:translation)), translation: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -60,10 +65,12 @@ defmodule I18NAPIWeb.TranslationControllerTest do
       conn: conn,
       translation: %Translation{id: id} = translation
     } do
-      conn = put(conn, translation_path(conn, :update, translation), translation: @update_attrs)
+      conn = put(conn, project_locale_translation_path(conn, :update, fixture(:project), translation.locale_id, translation),
+        translation: @update_attrs)
       assert %{"id" => ^id} = json_response(conn, 200)["data"]
 
-      conn = get(conn, translation_path(conn, :show, id))
+      conn = get(conn,
+        project_locale_translation_path(conn, :show, fixture(:project), translation.locale_id, translation, id))
 
       assert json_response(conn, 200)["data"] == %{
                "id" => id,
@@ -74,7 +81,8 @@ defmodule I18NAPIWeb.TranslationControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn, translation: translation} do
-      conn = put(conn, translation_path(conn, :update, translation), translation: @invalid_attrs)
+      conn = put(conn,
+        project_locale_translation_path(conn, :update, fixture(:project), translation.locale_id, translation, translation), translation: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -83,12 +91,12 @@ defmodule I18NAPIWeb.TranslationControllerTest do
     setup [:create_translation]
 
     test "deletes chosen translation", %{conn: conn, translation: translation} do
-      conn = delete(conn, translation_path(conn, :delete, translation))
+      conn = delete(conn, project_locale_translation_path(conn, :delete, fixture(:project), translation.locale_id, translation, translation))
       assert response(conn, 204)
 
       assert_error_sent(404, fn ->
-        get(conn, translation_path(conn, :show, translation))
-      end)
+          get(conn, project_locale_translation_path(conn, :show, fixture(:project), translation.locale_id, translation, translation))
+        end)
     end
   end
 

--- a/test/api_web/controllers/translation_key_controller_test.exs
+++ b/test/api_web/controllers/translation_key_controller_test.exs
@@ -34,23 +34,28 @@ defmodule I18NAPIWeb.TranslationKeyControllerTest do
     translation_key
   end
 
+  def fixture(:project) do
+    {:ok, project} = Projects.create_project(@create_attrs)
+    project
+  end
+
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 
   describe "index" do
     test "lists all translation_keys", %{conn: conn} do
-      conn = get(conn, translation_key_path(conn, :index))
+      conn = get(conn, project_translation_key_path(conn, :index, fixture(:project)))
       assert json_response(conn, 200)["data"] == []
     end
   end
 
   describe "create translation_key" do
     test "renders translation_key when data is valid", %{conn: conn} do
-      conn = post(conn, translation_key_path(conn, :create), translation_key: @create_attrs)
+      conn = post(conn, project_translation_key_path(conn, :create, fixture(:project)), translation_key: @create_attrs)
       assert %{"id" => id} = json_response(conn, 201)["data"]
 
-      conn = get(conn, translation_key_path(conn, :show, id))
+      conn = get(conn, project_translation_key_path(conn, :show, fixture(:project), id))
 
       assert json_response(conn, 200)["data"] == %{
                "id" => id,
@@ -64,7 +69,7 @@ defmodule I18NAPIWeb.TranslationKeyControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      conn = post(conn, translation_key_path(conn, :create), translation_key: @invalid_attrs)
+      conn = post(conn, project_translation_key_path(conn, :create, fixture(:project)), translation_key: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -79,13 +84,13 @@ defmodule I18NAPIWeb.TranslationKeyControllerTest do
       conn =
         put(
           conn,
-          translation_key_path(conn, :update, translation_key),
+          project_translation_key_path(conn, :update, fixture(:project), translation_key),
           translation_key: @update_attrs
         )
 
       assert %{"id" => ^id} = json_response(conn, 200)["data"]
 
-      conn = get(conn, translation_key_path(conn, :show, id))
+      conn = get(conn, project_translation_key_path(conn, :show, fixture(:project), id))
 
       assert json_response(conn, 200)["data"] == %{
                "id" => id,
@@ -102,7 +107,7 @@ defmodule I18NAPIWeb.TranslationKeyControllerTest do
       conn =
         put(
           conn,
-          translation_key_path(conn, :update, translation_key),
+          project_translation_key_path(conn, :update, fixture(:project), translation_key),
           translation_key: @invalid_attrs
         )
 
@@ -114,11 +119,11 @@ defmodule I18NAPIWeb.TranslationKeyControllerTest do
     setup [:create_translation_key]
 
     test "deletes chosen translation_key", %{conn: conn, translation_key: translation_key} do
-      conn = delete(conn, translation_key_path(conn, :delete, translation_key))
+      conn = delete(conn, project_translation_key_path(conn, :delete, fixture(:project), translation_key))
       assert response(conn, 204)
 
       assert_error_sent(404, fn ->
-        get(conn, translation_key_path(conn, :show, translation_key))
+        get(conn, project_translation_key_path(conn, :show, fixture(:project), translation_key))
       end)
     end
   end

--- a/test/api_web/controllers/translation_key_controller_test.exs
+++ b/test/api_web/controllers/translation_key_controller_test.exs
@@ -4,6 +4,12 @@ defmodule I18NAPIWeb.TranslationKeyControllerTest do
   alias I18NAPI.Translations
   alias I18NAPI.Translations.TranslationKey
 
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(I18NAPI.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(I18NAPI.Repo, {:shared, self()})
+    :ok
+  end
+
   @create_attrs %{
     context: "some context",
     is_removed: true,

--- a/test/api_web/controllers/user_controller_test.exs
+++ b/test/api_web/controllers/user_controller_test.exs
@@ -1,42 +1,25 @@
 defmodule I18NAPIWeb.UserControllerTest do
+  use ExUnit.Case, async: true
+  @moduletag :user_controller
+
   use I18NAPIWeb.ConnCase
 
   alias I18NAPI.Accounts
   alias I18NAPI.Accounts.User
 
   @create_attrs %{
-    confirmation_sent_at: ~N[2010-04-17 14:00:00.000000],
-    confirmation_token: "some confirmation_token",
-    confirmed_at: ~N[2010-04-17 14:00:00.000000],
-    email: "some email",
-    failed_restore_attempts: 42,
-    failed_sign_in_attempts: 42,
-    invited_at: ~N[2010-04-17 14:00:00.000000],
-    is_confirmed: true,
-    last_visited_at: ~N[2010-04-17 14:00:00.000000],
-    name: "some name",
-    password_hash: "some password_hash",
-    restore_accepted_at: ~N[2010-04-17 14:00:00.000000],
-    restore_requested_at: ~N[2010-04-17 14:00:00.000000],
-    restore_token: "some restore_token",
-    source: "some source"
+    name: "test name",
+    email: "test@email.test",
+    password: "Qw!23456",
+    password_confirmation: "Qw!23456",
+    source: "test source"
   }
   @update_attrs %{
-    confirmation_sent_at: ~N[2011-05-18 15:01:01.000000],
-    confirmation_token: "some updated confirmation_token",
-    confirmed_at: ~N[2011-05-18 15:01:01.000000],
-    email: "some updated email",
-    failed_restore_attempts: 43,
-    failed_sign_in_attempts: 43,
-    invited_at: ~N[2011-05-18 15:01:01.000000],
-    is_confirmed: false,
-    last_visited_at: ~N[2011-05-18 15:01:01.000000],
-    name: "some updated name",
-    password_hash: "some updated password_hash",
-    restore_accepted_at: ~N[2011-05-18 15:01:01.000000],
-    restore_requested_at: ~N[2011-05-18 15:01:01.000000],
-    restore_token: "some updated restore_token",
-    source: "some updated source"
+    name: "test updated name",
+    email: "test_updated@email.test",
+    password: "Qw!23456",
+    password_confirmation: "Qw!23456",
+    source: "test source"
   }
   @invalid_attrs %{
     confirmation_sent_at: nil,
@@ -56,19 +39,41 @@ defmodule I18NAPIWeb.UserControllerTest do
     source: nil
   }
 
+  @fixture_user_attrs %{
+    name: "fixture name",
+    email: "fixture@email.test",
+    password: "Qw!23456",
+    password_confirmation: "Qw!23456",
+    source: "fixture source"
+  }
+
   def fixture(:user) do
+    {:ok, user} = Accounts.create_user(@fixture_user_attrs)
+    user
+  end
+
+  def fixture(:alter_user) do
     {:ok, user} = Accounts.create_user(@create_attrs)
     user
   end
 
   setup %{conn: conn} do
-    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+    user = fixture(:user)
+    {:ok, jwt, _claims} = I18NAPI.Guardian.encode_and_sign(user)
+    conn =
+      conn
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("authorization", "Bearer #{jwt}")
+
+    {:ok, conn: conn}
   end
 
   describe "index" do
     test "lists all users", %{conn: conn} do
       conn = get(conn, user_path(conn, :index))
-      assert json_response(conn, 200)["data"] == []
+      [result|a] = json_response(conn, 200)["data"]
+      assert result["name"] == @fixture_user_attrs.name
+      assert result["email"] == @fixture_user_attrs.email
     end
   end
 
@@ -77,26 +82,9 @@ defmodule I18NAPIWeb.UserControllerTest do
       conn = post(conn, user_path(conn, :create), user: @create_attrs)
       assert %{"id" => id} = json_response(conn, 201)["data"]
 
-      conn = get(conn, user_path(conn, :show, id))
-
-      assert json_response(conn, 200)["data"] == %{
-               "id" => id,
-               "confirmation_sent_at" => ~N[2010-04-17 14:00:00.000000],
-               "confirmation_token" => "some confirmation_token",
-               "confirmed_at" => ~N[2010-04-17 14:00:00.000000],
-               "email" => "some email",
-               "failed_restore_attempts" => 42,
-               "failed_sign_in_attempts" => 42,
-               "invited_at" => ~N[2010-04-17 14:00:00.000000],
-               "is_confirmed" => true,
-               "last_visited_at" => ~N[2010-04-17 14:00:00.000000],
-               "name" => "some name",
-               "password_hash" => "some password_hash",
-               "restore_accepted_at" => ~N[2010-04-17 14:00:00.000000],
-               "restore_requested_at" => ~N[2010-04-17 14:00:00.000000],
-               "restore_token" => "some restore_token",
-               "source" => "some source"
-             }
+      assert %User{} = user = Accounts.get_user!(id)
+      assert user.name == @create_attrs.name
+      assert user.email == @create_attrs.email
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
@@ -106,35 +94,19 @@ defmodule I18NAPIWeb.UserControllerTest do
   end
 
   describe "update user" do
-    setup [:create_user]
 
-    test "renders user when data is valid", %{conn: conn, user: %User{id: id} = user} do
+    test "renders user when data is valid", %{conn: conn} do
+      user = fixture(:alter_user)
       conn = put(conn, user_path(conn, :update, user), user: @update_attrs)
-      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+      assert %{"id" => id} = json_response(conn, 200)["data"]
 
-      conn = get(conn, user_path(conn, :show, id))
-
-      assert json_response(conn, 200)["data"] == %{
-               "id" => id,
-               "confirmation_sent_at" => ~N[2011-05-18 15:01:01.000000],
-               "confirmation_token" => "some updated confirmation_token",
-               "confirmed_at" => ~N[2011-05-18 15:01:01.000000],
-               "email" => "some updated email",
-               "failed_restore_attempts" => 43,
-               "failed_sign_in_attempts" => 43,
-               "invited_at" => ~N[2011-05-18 15:01:01.000000],
-               "is_confirmed" => false,
-               "last_visited_at" => ~N[2011-05-18 15:01:01.000000],
-               "name" => "some updated name",
-               "password_hash" => "some updated password_hash",
-               "restore_accepted_at" => ~N[2011-05-18 15:01:01.000000],
-               "restore_requested_at" => ~N[2011-05-18 15:01:01.000000],
-               "restore_token" => "some updated restore_token",
-               "source" => "some updated source"
-             }
+      assert %User{} = user = Accounts.get_user!(id)
+      assert user.name == @update_attrs.name
+      assert user.email == @update_attrs.email
     end
 
-    test "renders errors when data is invalid", %{conn: conn, user: user} do
+    test "renders errors when data is invalid", %{conn: conn} do
+      user = fixture(:alter_user)
       conn = put(conn, user_path(conn, :update, user), user: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
@@ -143,7 +115,8 @@ defmodule I18NAPIWeb.UserControllerTest do
   describe "delete user" do
     setup [:create_user]
 
-    test "deletes chosen user", %{conn: conn, user: user} do
+    test "deletes chosen user", %{conn: conn} do
+      user = fixture(:alter_user)
       conn = delete(conn, user_path(conn, :delete, user))
       assert response(conn, 204)
 

--- a/test/api_web/controllers/user_controller_test.exs
+++ b/test/api_web/controllers/user_controller_test.exs
@@ -113,16 +113,15 @@ defmodule I18NAPIWeb.UserControllerTest do
   end
 
   describe "delete user" do
-    setup [:create_user]
-
     test "deletes chosen user", %{conn: conn} do
       user = fixture(:alter_user)
-      conn = delete(conn, user_path(conn, :delete, user))
-      assert response(conn, 204)
+      no_content_response = delete(conn, user_path(conn, :delete, user))
 
-      assert_error_sent(404, fn ->
-        get(conn, user_path(conn, :show, user))
-      end)
+      assert response(no_content_response, 204)
+
+      no_content_response = delete(conn, user_path(conn, :show, user))
+
+      assert response(no_content_response, 204)
     end
   end
 

--- a/test/api_web/controllers/user_controller_test.exs
+++ b/test/api_web/controllers/user_controller_test.exs
@@ -71,7 +71,7 @@ defmodule I18NAPIWeb.UserControllerTest do
   describe "index" do
     test "lists all users", %{conn: conn} do
       conn = get(conn, user_path(conn, :index))
-      [result|a] = json_response(conn, 200)["data"]
+      [result|_] = json_response(conn, 200)["data"]
       assert result["name"] == @fixture_user_attrs.name
       assert result["email"] == @fixture_user_attrs.email
     end
@@ -123,10 +123,5 @@ defmodule I18NAPIWeb.UserControllerTest do
 
       assert response(no_content_response, 204)
     end
-  end
-
-  defp create_user(_) do
-    user = fixture(:user)
-    {:ok, user: user}
   end
 end

--- a/test/api_web/controllers/user_roles_controller_test.exs
+++ b/test/api_web/controllers/user_roles_controller_test.exs
@@ -4,8 +4,8 @@ defmodule I18NAPIWeb.UserRolesControllerTest do
   alias I18NAPI.Projects
   alias I18NAPI.Projects.UserRoles
 
-  @create_attrs %{role: 42}
-  @update_attrs %{role: 43}
+  @create_attrs %{role: 0}
+  @update_attrs %{role: 1}
   @invalid_attrs %{role: nil}
 
   def fixture(:user_roles) do
@@ -26,11 +26,11 @@ defmodule I18NAPIWeb.UserRolesControllerTest do
 
   describe "create user_roles" do
     test "renders user_roles when data is valid", %{conn: conn} do
-      conn = post(conn, user_roles_path(conn, :create), user_roles: @create_attrs)
+      conn = post(conn, user_roles_path(conn, :create, fixture(:user_roles).project_id), user_roles: @create_attrs)
       assert %{"id" => id} = json_response(conn, 201)["data"]
 
       conn = get(conn, user_roles_path(conn, :show, id))
-      assert json_response(conn, 200)["data"] == %{"id" => id, "role" => 42}
+      assert json_response(conn, 200)["data"] == %{"id" => id, "role" => 0}
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
@@ -50,7 +50,7 @@ defmodule I18NAPIWeb.UserRolesControllerTest do
       assert %{"id" => ^id} = json_response(conn, 200)["data"]
 
       conn = get(conn, user_roles_path(conn, :show, id))
-      assert json_response(conn, 200)["data"] == %{"id" => id, "role" => 43}
+      assert json_response(conn, 200)["data"] == %{"id" => id, "role" => 1}
     end
 
     test "renders errors when data is invalid", %{conn: conn, user_roles: user_roles} do

--- a/test/api_web/views/error_view_test.exs
+++ b/test/api_web/views/error_view_test.exs
@@ -1,11 +1,25 @@
 defmodule I18NAPIWeb.ErrorViewTest do
+  use ExUnit.Case, async: true
+  @moduletag :error_view
+
   use I18NAPIWeb.ConnCase, async: true
 
   # Bring render/3 and render_to_string/3 for testing custom views
   import Phoenix.View
 
+  test "renders 400.json" do
+    assert render(I18NAPIWeb.ErrorView, "400.json", []) ==
+             %{errors: %{detail: "Bad Request"}}
+  end
+
+  test "renders 401.json" do
+    assert render(I18NAPIWeb.ErrorView, "401.json", []) ==
+             %{errors: %{detail: "Unauthorized"}}
+  end
+
   test "renders 404.json" do
-    assert render(I18NAPIWeb.ErrorView, "404.json", []) == %{errors: %{detail: "Not Found"}}
+    assert render(I18NAPIWeb.ErrorView, "404.json", []) ==
+             %{errors: %{detail: "Not Found"}}
   end
 
   test "renders 500.json" do


### PR DESCRIPTION
- After user successfully created, we send him email with confirmation_token link
- Fields confirmation_token and confirmation_send_data sets to user

- If we see request on /confirm/:token, we find user by token
- If user find successfully, we set user as is_confirmed and clean confirmation_token and confirmation_send_data. Then we send HTTP_response: 200
- If user find unsuccessfully, we send HTTP_response: 404